### PR TITLE
Properly depend on precompiled libraries if they have been enabled

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,7 +28,6 @@ AM_CPPFLAGS=-I$(top_srcdir)
 AM_CXXFLAGS = @TESTS_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS)  -I$(top_srcdir)/fflas-ffpack/ -I$(top_srcdir)/fflas-ffpack/utils/ -I$(top_srcdir)/fflas-ffpack/fflas/  -I$(top_srcdir)/fflas-ffpack/ffpack  -I$(top_srcdir)/fflas-ffpack/field $(GIVARO_CFLAGS) $(CBLAS_FLAG) $(CUDA_CFLAGS) $(PARFLAGS) $(PRECOMPILE_FLAGS)
 
-LDADD = $(CBLAS_LIBS) $(GIVARO_LIBS) $(CUDA_LIBS) $(PARFLAGS) $(PRECOMPILE_LIBS)
 AM_LDFLAGS=-static  #-L$(prefix)/lib   -lfflas -lffpack -lfflas_c -lffpack_c
 
 EXTRA_DIST= test-utils.h
@@ -51,9 +50,15 @@ BASIC_TESTS =               \
 		regression-check
 
 if FFLASFFPACK_PRECOMPILED
-
+LDADD = $(CBLAS_LIBS) $(GIVARO_LIBS) $(CUDA_LIBS) $(PARFLAGS) \
+	$(top_builddir)/fflas-ffpack/interfaces/libs/libfflas.la \
+	$(top_builddir)/fflas-ffpack/interfaces/libs/libffpack.la
 INTERFACE_TESTS= test-interfaces-c 
-test_interfaces_c_LDFLAGS = $(LDADD) -lfflas_c -lffpack_c
+test_interfaces_c_LDFLAGS = $(LDADD) \
+	$(top_builddir)/fflas-ffpack/interfaces/libs/libfflas_c.la \
+	$(top_builddir)/fflas-ffpack/interfaces/libs/libffpack_c.la
+else
+LDADD = $(CBLAS_LIBS) $(GIVARO_LIBS) $(CUDA_LIBS) $(PARFLAGS)
 endif
 NOT_A_TEST =  \
 		test-lqup2             \


### PR DESCRIPTION
At the moment running `make check` when `fflas-ffpack` has been configured with `--enable-precompilation` will fail when building the test programs. This is because in `tests/Makefile.am` we have 
```
LDADD = $(CBLAS_LIBS) $(GIVARO_LIBS) $(CUDA_LIBS) $(PARFLAGS) $(PRECOMPILE_LIBS)
```
and `PRECOMPILE_LIBS` indicate the final location of the libraries and their names. So it will actually work if you have previously installed them in a location known at configuration time. 

The proper way to deal with this is to add the appropriate `.la` files to `LDADD`. That way the build system knows where to find the libraries and will use `rpath` appropriately, so test will run without adding `LD_LIBRARY_PATH` or equivalent and the tested libraries will really be the one just built.