### PR TITLE
Use full path for including Mathio.h in tests.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,7 @@ check:
 
 AM_CPPFLAGS=-I$(top_srcdir) -g
 AM_CXXFLAGS = @TESTS_CFLAGS@ $(OPTFLAGS) $(GIVARO_CFLAGS) $(CBLAS_FLAG) $(CUDA_CFLAGS) $(PARFLAGS) $(PRECOMPILE_FLAGS)
-AM_CPPFLAGS +=  -I$(top_srcdir)/fflas-ffpack/ -I$(top_srcdir)/fflas-ffpack/utils/ -I$(top_srcdir)/fflas-ffpack/fflas/  -I$(top_srcdir)/fflas-ffpack/ffpack  -I$(top_srcdir)/fflas-ffpack/field 
+AM_CPPFLAGS +=  -I$(top_srcdir)/fflas-ffpack/
 
 #LDADD = $(CBLAS_LIBS) $(GIVARO_LIBS) $(CUDA_LIBS) $(PARFLAGS) $(PRECOMPILE_LIBS)
 AM_LDFLAGS=-static $(PARFLAGS) #-L$(prefix)/lib   -lfflas -lffpack -lfflas_c -lffpack_c

--- a/tests/benchfgemm.C
+++ b/tests/benchfgemm.C
@@ -31,7 +31,7 @@
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/field/modular-positive.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace std;
 using namespace FFPACK;

--- a/tests/benchlqup.C
+++ b/tests/benchlqup.C
@@ -28,7 +28,7 @@
 #include "fflas-ffpack/ffpack/ffpack.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace std;
 using namespace FFPACK;

--- a/tests/test-bini-p.C
+++ b/tests/test-bini-p.C
@@ -29,7 +29,7 @@
 
 
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/fflas/fflas.h"
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include "test-utils.h"

--- a/tests/test-colechelon.C
+++ b/tests/test-colechelon.C
@@ -45,7 +45,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/ffpack/ffpack.h"

--- a/tests/test-compressQ.C
+++ b/tests/test-compressQ.C
@@ -47,7 +47,7 @@
 #include "fflas-ffpack/ffpack/ffpack.h"
 #include "fflas-ffpack/utils/args-parser.h"
 
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace std;
 typedef Givaro::Modular<double> Field;

--- a/tests/test-det.C
+++ b/tests/test-det.C
@@ -44,7 +44,7 @@
 #include "fflas-ffpack/utils/args-parser.h"
 
 #include "test-utils.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 
 // using namespace std;

--- a/tests/test-echelon.C
+++ b/tests/test-echelon.C
@@ -45,7 +45,7 @@
 #include "fflas-ffpack/utils/args-parser.h"
 
 #include "test-utils.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace std;
 using namespace FFPACK;

--- a/tests/test-echelon_old.C
+++ b/tests/test-echelon_old.C
@@ -46,7 +46,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/ffpack/ffpack.h"

--- a/tests/test-fadd.C
+++ b/tests/test-fadd.C
@@ -37,7 +37,7 @@
 #include "fflas-ffpack/fflas/fflas.h"
 #include "fflas-ffpack/utils/args-parser.h"
 
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "test-utils.h"
 #include "assert.h"
 

--- a/tests/test-fgemv.C
+++ b/tests/test-fgemv.C
@@ -46,7 +46,7 @@
 #include <iomanip>
 #include <iostream>
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/fflas/fflas.h"
 
 

--- a/tests/test-fger.C
+++ b/tests/test-fger.C
@@ -49,7 +49,7 @@
 #include "fflas-ffpack/utils/args-parser.h"
 
 #include "test-utils.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace std;
 using namespace FFPACK;

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -43,7 +43,7 @@ using namespace std;
 
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 
 

--- a/tests/test-finit.C
+++ b/tests/test-finit.C
@@ -39,7 +39,7 @@
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include "fflas-ffpack/utils/args-parser.h"
 
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "test-utils.h"
 #include "assert.h"
 

--- a/tests/test-fscal.C
+++ b/tests/test-fscal.C
@@ -35,7 +35,7 @@
 #include "fflas-ffpack/fflas/fflas.h"
 #include "fflas-ffpack/utils/args-parser.h"
 
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "test-utils.h"
 #include "assert.h"
 

--- a/tests/test-fsquare.C
+++ b/tests/test-fsquare.C
@@ -41,7 +41,7 @@
 #include <iostream>
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/fflas/fflas.h"
 
 

--- a/tests/test-ftrtri.C
+++ b/tests/test-ftrtri.C
@@ -43,7 +43,7 @@
 #include "fflas-ffpack/fflas-ffpack-config.h"
 
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 
 

--- a/tests/test-fullranksubmatrix.C
+++ b/tests/test-fullranksubmatrix.C
@@ -38,7 +38,7 @@
 #include <iostream>
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 
 

--- a/tests/test-krylov-elim.C
+++ b/tests/test-krylov-elim.C
@@ -38,7 +38,7 @@
 //#define DEBUG 0
 
 #include <iostream>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 using namespace std;
 #include "fflas-ffpack/field/modular-balanced.h"

--- a/tests/test-nullspace.C
+++ b/tests/test-nullspace.C
@@ -42,7 +42,7 @@ using namespace std;
 #include <iostream>
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 
 

--- a/tests/test-rank.C
+++ b/tests/test-rank.C
@@ -38,7 +38,7 @@
 #include <iostream>
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 
 

--- a/tests/test-rankprofiles.C
+++ b/tests/test-rankprofiles.C
@@ -39,7 +39,7 @@
 #include <givaro/modular.h>
 
 #include "test-utils.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 
 using namespace FFPACK;
 

--- a/tests/test-redcolechelon.C
+++ b/tests/test-redcolechelon.C
@@ -45,7 +45,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/ffpack/ffpack.h"

--- a/tests/test-redechelon.C
+++ b/tests/test-redechelon.C
@@ -45,7 +45,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/ffpack/ffpack.h"

--- a/tests/test-redrowechelon.C
+++ b/tests/test-redrowechelon.C
@@ -45,7 +45,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 //#include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/field/modular-positive.h"

--- a/tests/test-rowechelon.C
+++ b/tests/test-rowechelon.C
@@ -45,7 +45,7 @@ using namespace std;
 //#define __LUDIVINE_CUTOFF 1
 #include <iostream>
 #include <iomanip>
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/utils/timer.h"
 //#include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/field/modular-positive.h"

--- a/tests/testeur_fgemm.C
+++ b/tests/testeur_fgemm.C
@@ -15,7 +15,7 @@ using namespace std;
 //#include "fflas-ffpack/modular-positive.h"
 #include "fflas-ffpack/field/modular-positive.h"
 //#include "timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/fflas/fflas.h"
 
 

--- a/tests/testeur_ftrsm.C
+++ b/tests/testeur_ftrsm.C
@@ -35,7 +35,7 @@
 #include "fflas-ffpack/field/modular-balanced.h"
 //#include "fflas-ffpack/field/modular-int.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/fflas/fflas.h"
 #include "givaro/givintprime.h"
 

--- a/tests/testeur_lqup.C
+++ b/tests/testeur_lqup.C
@@ -39,7 +39,7 @@ using namespace std;
 //#include "fflas-ffpack/field/modular-positive.h"
 #include "fflas-ffpack/field/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
-#include "Matio.h"
+#include "fflas-ffpack/utils/Matio.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
 #include "givaro/givintprime.h"
 


### PR DESCRIPTION
This makes it easier to run the tests against an installed fflas-ffpack, as
we don't need to worry about an extra -I flag.

Since these -I flags are no longer necessary, they have been removed from
the tests Makefile as well.