### PR TITLE
Fix access to mpz_t limbs on big endian architectures

### DIFF
--- a/fflas-ffpack/field/rns-double-recint.inl
+++ b/fflas-ffpack/field/rns-double-recint.inl
@@ -68,18 +68,13 @@ namespace FFPACK {
 					  
 					  //size_t maxs=std::min(k,(Aiter[j+i*lda].size())*sizeof(mp_limb_t)/2);// to ensure 32 bits portability
 
+					  for (;l<maxs;l++){
 #ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
-					  for (;l<maxs;l++){
 						  A_beta[l+idx*k]= m0_ptr[l];						  
-
-					  }
 #else
-					  size_t mask = (sizeof(mp_limb_t)/2) - 1;
-					  for (;l<maxs;l++){
-						  size_t l2 = (l & ~mask) | (l ^ mask);
-						  A_beta[l+idx*k]= m0_ptr[l2];
-					  }
+						  A_beta[l+idx*k]= m0_ptr[l^((sizeof(mp_limb_t)/2U)-1U)];
 #endif
+					  }
 					  for (;l<k;l++)
 						  A_beta[l+idx*k]=  0.;
 
@@ -219,11 +214,10 @@ namespace FFPACK {
 						A2[l+2]= tptr[2];
 						A3[l+3]= tptr[3];
 #else
-						size_t mask = (sizeof(mp_limb_t)/2) - 1;
-						A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
-						A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
-						A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
-						A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+						A0[l     ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[3];
+						A1[(l+1) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[2];
+						A2[(l+2) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[1];
+						A3[(l+3) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[0];
 #endif
 					}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3
@@ -311,11 +305,10 @@ namespace FFPACK {
 						A2[l+2]= tptr[2];
 						A3[l+3]= tptr[3];
 #else
-						size_t mask = (sizeof(mp_limb_t)/2) - 1;
-						A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
-						A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
-						A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
-						A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+						A0[l     ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[3];
+						A1[(l+1) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[2];
+						A2[(l+2) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[1];
+						A3[(l+3) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[0];
 #endif
 					
 					}

--- a/fflas-ffpack/field/rns-double-recint.inl
+++ b/fflas-ffpack/field/rns-double-recint.inl
@@ -68,9 +68,18 @@ namespace FFPACK {
 					  
 					  //size_t maxs=std::min(k,(Aiter[j+i*lda].size())*sizeof(mp_limb_t)/2);// to ensure 32 bits portability
 
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 					  for (;l<maxs;l++){
 						  A_beta[l+idx*k]= m0_ptr[l];						  
+
 					  }
+#else
+					  size_t mask = (sizeof(mp_limb_t)/2) - 1;
+					  for (;l<maxs;l++){
+						  size_t l2 = (l & ~mask) | (l ^ mask);
+						  A_beta[l+idx*k]= m0_ptr[l2];
+					  }
+#endif
 					  for (;l<k;l++)
 						  A_beta[l+idx*k]=  0.;
 
@@ -204,10 +213,18 @@ namespace FFPACK {
 					for (size_t l=0;l<k;l++){
 						uint64_t tmp=(uint64_t)A_beta[l+idx*k];
 						uint16_t* tptr= reinterpret_cast<uint16_t*>(&tmp);
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 						A0[l  ]= tptr[0];
 						A1[l+1]= tptr[1];
 						A2[l+2]= tptr[2];
 						A3[l+3]= tptr[3];
+#else
+						size_t mask = (sizeof(mp_limb_t)/2) - 1;
+						A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
+						A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
+						A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
+						A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+#endif
 					}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3
 					m0[0]->_mp_d= reinterpret_cast<mp_limb_t*>(&A0[0]);
@@ -288,10 +305,18 @@ namespace FFPACK {
 					for (size_t l=0;l<k;l++){
 						uint64_t tmp=(uint64_t)A_beta[l+idx*k];					
 						uint16_t* tptr= reinterpret_cast<uint16_t*>(&tmp);
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 						A0[l  ]= tptr[0];
 						A1[l+1]= tptr[1];
 						A2[l+2]= tptr[2];
 						A3[l+3]= tptr[3];
+#else
+						size_t mask = (sizeof(mp_limb_t)/2) - 1;
+						A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
+						A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
+						A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
+						A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+#endif
 					
 					}
 					a0= reinterpret_cast<RecInt::ruint<K>*>(&A0[0]);

--- a/fflas-ffpack/field/rns-double.h
+++ b/fflas-ffpack/field/rns-double.h
@@ -179,8 +179,16 @@ namespace FFPACK {
 				}
 				*/
 				size_t l=0;
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 				for(;l<maxs;l++)
 					_crt_out[l+i*_ldm]=m0_ptr[l];
+#else
+				size_t mask = (sizeof(mp_limb_t)/2) - 1;
+				for(;l<maxs;l++) {
+					size_t l2 = (l & ~mask) | (l ^ mask);
+					_crt_out[l+i*_ldm]=m0_ptr[l2];
+				}
+#endif
 				for(;l<_ldm;l++)
 					_crt_out[l+i*_ldm]=0.;;
 				// chrono.stop();

--- a/fflas-ffpack/field/rns-double.h
+++ b/fflas-ffpack/field/rns-double.h
@@ -183,11 +183,8 @@ namespace FFPACK {
 				for(;l<maxs;l++)
 					_crt_out[l+i*_ldm]=m0_ptr[l];
 #else
-				size_t mask = (sizeof(mp_limb_t)/2) - 1;
-				for(;l<maxs;l++) {
-					size_t l2 = (l & ~mask) | (l ^ mask);
-					_crt_out[l+i*_ldm]=m0_ptr[l2];
-				}
+				for(;l<maxs;l++)
+					_crt_out[l+i*_ldm]=m0_ptr[l ^ ((sizeof(mp_limb_t)/2U) - 1U)];
 #endif
 				for(;l<_ldm;l++)
 					_crt_out[l+i*_ldm]=0.;;

--- a/fflas-ffpack/field/rns-double.inl
+++ b/fflas-ffpack/field/rns-double.inl
@@ -76,15 +76,14 @@ namespace FFPACK {
 						  for (;l<maxs;l++)
 							  A_beta[l+idx*k]= - double(m0_ptr[l]);
 #else
-					  size_t mask = (sizeof(mp_limb_t)/2) - 1;
 					  if (m0[0]->_mp_size >= 0)
 						  for (;l<maxs;l++) {
-							  size_t l2 = (l & ~mask) | (l ^ mask);
+							  size_t l2 = l ^ ((sizeof(mp_limb_t)/2U) - 1U);
 							  A_beta[l+idx*k]=  m0_ptr[l2];
 						  }
 					  else
 						  for (;l<maxs;l++) {
-							  size_t l2 = (l & ~mask) | (l ^ mask);
+							  size_t l2 = l ^ ((sizeof(mp_limb_t)/2U) - 1U);
 							  A_beta[l+idx*k]= - double(m0_ptr[l2]);
 						  }
 #endif
@@ -172,15 +171,14 @@ namespace FFPACK {
 					for (;l<maxs;l++)
 						A_beta[l+idx*k]= - double(m0_ptr[l]);
 #else
-				size_t mask = (sizeof(mp_limb_t)/2) - 1;
 				if (m0[0]->_mp_size >= 0)
 					for (;l<maxs;l++) {
-						size_t l2 = (l & ~mask) | (l ^ mask);
+						size_t l2 = l ^ ((sizeof(mp_limb_t)/2U) - 1U);
 						A_beta[l+idx*k]=  m0_ptr[l2];
 					}
 				else
 					for (;l<maxs;l++) {
-						size_t l2 = (l & ~mask) | (l ^ mask);
+						size_t l2 = l ^ ((sizeof(mp_limb_t)/2U) - 1U);
 						A_beta[l+idx*k]= - double(m0_ptr[l2]);
 					}
 #endif
@@ -277,11 +275,10 @@ namespace FFPACK {
 					A2[l+2]= tptr[2];
 					A3[l+3]= tptr[3];
 #else
-					size_t mask = (sizeof(mp_limb_t)/2) - 1;
-					A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
-					A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
-					A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
-					A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+					A0[l     ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[3];
+					A1[(l+1) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[2];
+					A2[(l+2) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[1];
+					A3[(l+3) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[0];
 #endif
 				}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3
@@ -380,11 +377,10 @@ namespace FFPACK {
 					A2[l+2]= tptr[2];
 					A3[l+3]= tptr[3];
 #else
-					size_t mask = (sizeof(mp_limb_t)/2) - 1;
-					A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
-					A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
-					A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
-					A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+					A0[l     ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[3];
+					A1[(l+1) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[2];
+					A2[(l+2) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[1];
+					A3[(l+3) ^ ((sizeof(mp_limb_t)/2U) - 1U)] = tptr[0];
 #endif
 				}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3

--- a/fflas-ffpack/field/rns-double.inl
+++ b/fflas-ffpack/field/rns-double.inl
@@ -68,12 +68,26 @@ namespace FFPACK {
 						  //size_t maxs=std::min(k,(Aiter[j+i*lda].size())<<2);
 					  size_t maxs=std::min(k,(Aiter[j+i*lda].size())*sizeof(mp_limb_t)/2);// to ensure 32 bits portability
 
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 					  if (m0[0]->_mp_size >= 0)
 						  for (;l<maxs;l++)
 							  A_beta[l+idx*k]=  m0_ptr[l];
 					  else
 						  for (;l<maxs;l++)
 							  A_beta[l+idx*k]= - double(m0_ptr[l]);
+#else
+					  size_t mask = (sizeof(mp_limb_t)/2) - 1;
+					  if (m0[0]->_mp_size >= 0)
+						  for (;l<maxs;l++) {
+							  size_t l2 = (l & ~mask) | (l ^ mask);
+							  A_beta[l+idx*k]=  m0_ptr[l2];
+						  }
+					  else
+						  for (;l<maxs;l++) {
+							  size_t l2 = (l & ~mask) | (l ^ mask);
+							  A_beta[l+idx*k]= - double(m0_ptr[l2]);
+						  }
+#endif
 					  for (;l<k;l++)
 						  A_beta[l+idx*k]=  0.;
 
@@ -150,12 +164,26 @@ namespace FFPACK {
 				size_t l=0;
 					//size_t maxs=std::min(k,(Aiter[j+i*lda].size())<<2);
 				size_t maxs=std::min(k,(Aiter[j+i*lda].size())*sizeof(mp_limb_t)/2); // to ensure 32 bits portability
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 				if (m0[0]->_mp_size >= 0)
 					for (;l<maxs;l++)
 						A_beta[l+idx*k]=  m0_ptr[l];
 				else
 					for (;l<maxs;l++)
 						A_beta[l+idx*k]= - double(m0_ptr[l]);
+#else
+				size_t mask = (sizeof(mp_limb_t)/2) - 1;
+				if (m0[0]->_mp_size >= 0)
+					for (;l<maxs;l++) {
+						size_t l2 = (l & ~mask) | (l ^ mask);
+						A_beta[l+idx*k]=  m0_ptr[l2];
+					}
+				else
+					for (;l<maxs;l++) {
+						size_t l2 = (l & ~mask) | (l ^ mask);
+						A_beta[l+idx*k]= - double(m0_ptr[l2]);
+					}
+#endif
 				for (;l<k;l++)
 					A_beta[l+idx*k]=  0.;
 			}
@@ -243,10 +271,18 @@ namespace FFPACK {
 				for (size_t l=0;l<k;l++){
 					uint64_t tmp=(uint64_t)A_beta[l+idx*k];
 					uint16_t* tptr= reinterpret_cast<uint16_t*>(&tmp);
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 					A0[l  ]= tptr[0];
 					A1[l+1]= tptr[1];
 					A2[l+2]= tptr[2];
 					A3[l+3]= tptr[3];
+#else
+					size_t mask = (sizeof(mp_limb_t)/2) - 1;
+					A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
+					A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
+					A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
+					A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+#endif
 				}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3
 				m0[0]->_mp_d= reinterpret_cast<mp_limb_t*>(&A0[0]);
@@ -338,10 +374,18 @@ namespace FFPACK {
 				for (size_t l=0;l<k;l++){
 					uint64_t tmp=(uint64_t)A_beta[l+idx*k];
 					uint16_t* tptr= reinterpret_cast<uint16_t*>(&tmp);
+#ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 					A0[l  ]= tptr[0];
 					A1[l+1]= tptr[1];
 					A2[l+2]= tptr[2];
 					A3[l+3]= tptr[3];
+#else
+					size_t mask = (sizeof(mp_limb_t)/2) - 1;
+					A0[(l     & ~mask) | (l     ^ mask)] = tptr[3];
+					A1[((l+1) & ~mask) | ((l+1) ^ mask)] = tptr[2];
+					A2[((l+2) & ~mask) | ((l+2) ^ mask)] = tptr[1];
+					A3[((l+3) & ~mask) | ((l+3) ^ mask)] = tptr[0];
+#endif
 				}
 					// see A0,A1,A2,A3 as a the gmp integers a0,a1,a2,a3
 				m0[0]->_mp_d= reinterpret_cast<mp_limb_t*>(&A0[0]);


### PR DESCRIPTION
This is a partial fix to issue 45.