### PR TITLE
Add "#include <functional>" to test-utils.h; fixes build failure with…

### DIFF
--- a/tests/test-utils.h
+++ b/tests/test-utils.h
@@ -44,6 +44,7 @@
 #include <givaro/givranditer.h>
 #include <chrono>
 #include <random>
+#include <functional>
 
 namespace FFPACK {
 


### PR DESCRIPTION
… GCC 7.

Closes #74.