### PR TITLE
Freed previously unfreed matrices

### DIFF
--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -87,6 +87,8 @@ int main(int argc, char** argv) {
 		
 		time+=chrono.usertime();
 		FFLAS::fflas_delete( A);
+		FFLAS::fflas_delete( C);
+		FFLAS::fflas_delete( D);
 	}
   
 		// -----------


### PR DESCRIPTION
Several allocated matrices were not freed at the end of `benchmark-fsyrk`, leading to memory leaks.
This small branch fixes that.