### PR TITLE
Benchmark ftrtri : changed usertime to real time

### DIFF
--- a/autotune/ftrtri.C
+++ b/autotune/ftrtri.C
@@ -101,7 +101,7 @@ int main () {
 			tim+=chrono;
 			FFLAS::fassign (F, n, n, T, ldt, U, ldt);
 		}
-		RecTime = tim.usertime()/iter;
+		RecTime = tim.realtime()/iter;
 
 		cout << "      ";
 		cout.width(4);

--- a/benchmarks/benchmark-ftrtri.C
+++ b/benchmarks/benchmark-ftrtri.C
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
 			FFPACK::ftrtri(F, FFLAS::FflasUpper, FFLAS::FflasNonUnit, n, A, n);
 		if (i) chrono.stop();
 		
-		time+=chrono.usertime();
+		time+=chrono.realtime();
 	}
 		FFLAS::fflas_delete (A);
 		FFLAS::fflas_delete (B);


### PR DESCRIPTION
This gives more coherence to the values returned by the benchmark when plotted.