### PR TITLE
revert cerr and cout for creating thresholds from autotune

### DIFF
--- a/autotune/arithprog.C
+++ b/autotune/arithprog.C
@@ -76,14 +76,14 @@ int main (int argc, char** argv) {
 	FFLAS::fassign (F, dim, dim, A, dim, B, dim);
 	typedef typename Givaro::Poly1Dom<Field>::Element Polynomial;
 	time_t result = std::time(NULL);
-	cout << std::endl 
+	cerr << std::endl 
 		 << "---------------------------------------------------------------------"
 		 << std::endl << std::asctime(std::localtime(&result))
 		 << std::endl
 		 << "Threshold for ArithProg CharPoly algorithm";
-	F.write(cout << " (using ") << ')' << endl << endl;
+	F.write(cerr << " (using ") << ')' << endl << endl;
 
-	cout << "Charpoly:  n = "<<dim<<"  block_size   seconds            Gfops"<< std::endl;
+	cerr << "Charpoly:  n = "<<dim<<"  block_size   seconds            Gfops"<< std::endl;
 	double CurrTime;
 	double PrevTime = 1000000;
 	double BestTime = 1000000;
@@ -110,15 +110,15 @@ int main (int argc, char** argv) {
 		}
 		CurrTime = tim.realtime()/iter;
 
-		cout << "                           ";
-		cout.width(4);
-		cout << n;
-		cout << "  ";
-		cout.width(15);
-		cout << CurrTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(dim,dim,r, CurrTime) << "  "<<std::endl;
+		cerr << "                           ";
+		cerr.width(4);
+		cerr << n;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << CurrTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(dim,dim,r, CurrTime) << "  "<<std::endl;
 
 		if (BestTime > CurrTime){ // time decreasing -> keep increasing the block size
 			nbest = n;
@@ -132,12 +132,12 @@ int main (int argc, char** argv) {
 		n += step;
 	} while ( (increasing < confirm ) && (n < nmax));
 
-	cout<<endl;
+	cerr<<endl;
 	if (nbest != 0 ) {
-		cerr << "#ifndef __FFLASFFPACK_ARITHPROG_THRESHOLD"<< endl;
-		cerr << "#define __FFLASFFPACK_ARITHPROG_THRESHOLD" << ' ' << nbest << endl;
-		cout << "defined __FFLASFFPACK_ARITHPROG_THRESHOLD to " << nbest << std::endl;
-		std::cerr << "#endif" << endl  << endl;
+		cout << "#ifndef __FFLASFFPACK_ARITHPROG_THRESHOLD"<< endl;
+		cout << "#define __FFLASFFPACK_ARITHPROG_THRESHOLD" << ' ' << nbest << endl;
+		cerr << "defined __FFLASFFPACK_ARITHPROG_THRESHOLD to " << nbest << std::endl;
+		std::cout << "#endif" << endl  << endl;
 	}
 	FFLAS::fflas_delete(A);
 	FFLAS::fflas_delete(B);

--- a/autotune/charpoly.C
+++ b/autotune/charpoly.C
@@ -73,15 +73,15 @@ int main () {
 	time_t result = std::time(NULL);
 	string var1 = (VARIANT1 == FfpackLUK)?"LUKrylov":"Danilevskii";
 	string var2 = (VARIANT2 == FfpackLUK)?"LUKrylov":"ArithProg";
-	cout << std::endl 
+	cerr << std::endl 
 		 << "---------------------------------------------------------------------"
 		 << std::endl << std::asctime(std::localtime(&result))
 		 << std::endl
 		 << "Threshold between CharPoly algorithms "<<var1<<" <-> "<<var2 ;
-	F.write(cout << " (using ") << ')' << endl << endl;
+	F.write(cerr << " (using ") << ')' << endl << endl;
 
-	cout << "Charpoly:  n                   "<<var1<<"                        "<<var2 << std::endl;
-	cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+	cerr << "Charpoly:  n                   "<<var1<<"                        "<<var2 << std::endl;
+	cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
 		do {
 		double Var1Time, Var2Time;
 		int iter=ITER;
@@ -112,20 +112,20 @@ int main () {
 			//FFLAS::fflas_delete(B);
 		Var2Time = tim.realtime()/iter;
 
-		cout << "      ";
-		cout.width(4);
-		cout << n;
-		cout << "  ";
-		cout.width(15);
-		cout << Var1Time;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n,n,r, Var1Time) << "  ";
-		cout.width(15);
-		cout << Var2Time;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n,n,r, Var2Time) << endl;
+		cerr << "      ";
+		cerr.width(4);
+		cerr << n;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << Var1Time;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n,n,r, Var1Time) << "  ";
+		cerr.width(15);
+		cerr << Var2Time;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n,n,r, Var2Time) << endl;
 
 		if (Var1Time > Var2Time){
 			count++;
@@ -144,12 +144,12 @@ int main () {
 		}
 	} while ((prec > NPREC ) && (n < nmax));
 
-	cout<<endl;
+	cerr<<endl;
 	if (nbest != 0 ) {
-		cerr << "#ifndef __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD"  << endl;
-		cerr << "#define __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD" << ' ' <<  nbest << endl;
-		cout << "defined __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD to " << nbest << "" << std::endl;
-		std::cerr << "#endif" << endl  << endl;
+		cout << "#ifndef __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD"  << endl;
+		cout << "#define __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD" << ' ' <<  nbest << endl;
+		cerr << "defined __FFLASFFPACK_CHARPOLY_"<<var1<<"_"<<var2<<"_THRESHOLD to " << nbest << "" << std::endl;
+		std::cout << "#endif" << endl  << endl;
 	}
 	FFLAS::fflas_delete(A);
 	FFLAS::fflas_delete(B);

--- a/autotune/fsyrk.C
+++ b/autotune/fsyrk.C
@@ -81,15 +81,15 @@ int main () {
   // let alpha and beta be scalars in F
   Field::Element alpha = F.mOne, beta = F.one;
   
-  cout << std::endl 
+  cerr << std::endl 
        << "---------------------------------------------------------------------"
        << std::endl << std::asctime(std::localtime(&result))
        << std::endl
        << "Threshold for fsyrk base case" ;
-  F.write(cout << " (using ") << ')' << endl << endl;
+  F.write(cerr << " (using ") << ')' << endl << endl;
 
-  cout << "fsyrk:  n                   Base case                        Recursive 1 level" << std::endl;
-  cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+  cerr << "fsyrk:  n                   Base case                        Recursive 1 level" << std::endl;
+  cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
   double BCTime, RecTime;
   int iter;
   do{
@@ -120,20 +120,20 @@ int main () {
     }
     RecTime = tim.realtime()/iter;
 
-    cout << "      ";
-    cout.width(4);
-    cout << n;
-    cout << "  ";
-    cout.width(15);
-    cout << BCTime;
-    cout << "  ";
-    cout.width(15);
-    cout << GFOPS(n, BCTime) << "  ";
-    cout.width(15);
-    cout << RecTime;
-    cout << "  ";
-    cout.width(15);
-    cout << GFOPS(n, RecTime) << endl;
+    cerr << "      ";
+    cerr.width(4);
+    cerr << n;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << BCTime;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << GFOPS(n, BCTime) << "  ";
+    cerr.width(15);
+    cerr << RecTime;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << GFOPS(n, RecTime) << endl;
 
     if (BCTime > RecTime){
       count++;
@@ -152,12 +152,12 @@ int main () {
     }
   } while ((prec > 1 ) && (n < nmax));
 
-  cout<<endl;
+  cerr<<endl;
   if (nbest != 0 ) {
-    cerr << "#ifndef __FFLASFFPACK_FSYRK_THRESHOLD"  << endl;
-    cerr << "#define __FFLASFFPACK_FSYRK_THRESHOLD" << ' ' <<  nbest << endl;
-    cout << "defined __FFLASFFPACK_FSYRK_THRESHOLD to " << nbest << "" << std::endl;
-    std::cerr << "#endif" << endl  << endl;
+    cout << "#ifndef __FFLASFFPACK_FSYRK_THRESHOLD"  << endl;
+    cout << "#define __FFLASFFPACK_FSYRK_THRESHOLD" << ' ' <<  nbest << endl;
+    cerr << "defined __FFLASFFPACK_FSYRK_THRESHOLD to " << nbest << "" << std::endl;
+    std::cout << "#endif" << endl  << endl;
   }
   FFLAS::fflas_delete(A);
   FFLAS::fflas_delete(B);

--- a/autotune/fsytrf.C
+++ b/autotune/fsytrf.C
@@ -68,15 +68,15 @@ int main () {
   Field::Element_ptr B = FFLAS::fflas_new (F, nmax, nmax);
   FFLAS::fassign (F, n, n, A, lda, B, lda);
   
-  cout << std::endl 
+  cerr << std::endl 
        << "---------------------------------------------------------------------"
        << std::endl << std::asctime(std::localtime(&result))
        << std::endl
        << "Threshold for fsytrf base case" ;
-  F.write(cout << " (using ") << ')' << endl << endl;
+  F.write(cerr << " (using ") << ')' << endl << endl;
 
-  cout << "fsytrf:  n                   Base case                        Recursive 1 level" << std::endl;
-  cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+  cerr << "fsytrf:  n                   Base case                        Recursive 1 level" << std::endl;
+  cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
   double BCTime, RecTime;
   int iter;
   do{
@@ -107,20 +107,20 @@ int main () {
     }
     RecTime = tim.realtime()/iter;
 
-    cout << "      ";
-    cout.width(4);
-    cout << n;
-    cout << "  ";
-    cout.width(15);
-    cout << BCTime;
-    cout << "  ";
-    cout.width(15);
-    cout << GFOPS(n, BCTime) << "  ";
-    cout.width(15);
-    cout << RecTime;
-    cout << "  ";
-    cout.width(15);
-    cout << GFOPS(n, RecTime) << endl;
+    cerr << "      ";
+    cerr.width(4);
+    cerr << n;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << BCTime;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << GFOPS(n, BCTime) << "  ";
+    cerr.width(15);
+    cerr << RecTime;
+    cerr << "  ";
+    cerr.width(15);
+    cerr << GFOPS(n, RecTime) << endl;
 
     if (BCTime > RecTime){
       count++;
@@ -139,12 +139,12 @@ int main () {
     }
   } while ((prec > 1 ) && (n < nmax));
 
-  cout<<endl;
+  cerr<<endl;
   if (nbest != 0 ) {
-    cerr << "#ifndef __FFLASFFPACK_FSYTRF_THRESHOLD"  << endl;
-    cerr << "#define __FFLASFFPACK_FSYTRF_THRESHOLD" << ' ' <<  nbest << endl;
-    cout << "defined __FFLASFFPACK_FSYTRF_THRESHOLD to " << nbest << "" << std::endl;
-    std::cerr << "#endif" << endl  << endl;
+    cout << "#ifndef __FFLASFFPACK_FSYTRF_THRESHOLD"  << endl;
+    cout << "#define __FFLASFFPACK_FSYTRF_THRESHOLD" << ' ' <<  nbest << endl;
+    cerr << "defined __FFLASFFPACK_FSYTRF_THRESHOLD to " << nbest << "" << std::endl;
+    std::cout << "#endif" << endl  << endl;
   }
   FFLAS::fflas_delete(A);
   FFLAS::fflas_delete(B);

--- a/autotune/ftrtri.C
+++ b/autotune/ftrtri.C
@@ -64,15 +64,15 @@ int main () {
 	time_t result = std::time(NULL);
 	Field::Element_ptr U = FFLAS::fflas_new (F, nmax, nmax);
 	FFLAS::fassign (F, n, n, U, ldt, T, ldt);
-	cout << std::endl 
+	cerr << std::endl 
 		 << "---------------------------------------------------------------------"
 		 << std::endl << std::asctime(std::localtime(&result))
 		 << std::endl
 		 << "Threshold for ftrtri base case" ;
-	F.write(cout << " (using ") << ')' << endl << endl;
+	F.write(cerr << " (using ") << ')' << endl << endl;
 
-	cout << "ftrtri:  n                   Base case                        Recursive 1 level" << std::endl;
-	cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+	cerr << "ftrtri:  n                   Base case                        Recursive 1 level" << std::endl;
+	cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
 	double BCTime, RecTime;
 	int iter;
 	do{
@@ -103,20 +103,20 @@ int main () {
 		}
 		RecTime = tim.realtime()/iter;
 
-		cout << "      ";
-		cout.width(4);
-		cout << n;
-		cout << "  ";
-		cout.width(15);
-		cout << BCTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n, BCTime) << "  ";
-		cout.width(15);
-		cout << RecTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n, RecTime) << endl;
+		cerr << "      ";
+		cerr.width(4);
+		cerr << n;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << BCTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n, BCTime) << "  ";
+		cerr.width(15);
+		cerr << RecTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n, RecTime) << endl;
 
 		if (BCTime > RecTime){
 			count++;
@@ -135,12 +135,12 @@ int main () {
 		}
 	} while ((prec > 1 ) && (n < nmax));
 
-	cout<<endl;
+	cerr<<endl;
 	if (nbest != 0 ) {
-		cerr << "#ifndef __FFLASFFPACK_FTRTRI_THRESHOLD"  << endl;
-		cerr << "#define __FFLASFFPACK_FTRTRI_THRESHOLD" << ' ' <<  nbest << endl;
-		cout << "defined __FFLASFFPACK_FTRTRI_THRESHOLD to " << nbest << "" << std::endl;
-		std::cerr << "#endif" << endl  << endl;
+		cout << "#ifndef __FFLASFFPACK_FTRTRI_THRESHOLD"  << endl;
+		cout << "#define __FFLASFFPACK_FTRTRI_THRESHOLD" << ' ' <<  nbest << endl;
+		cerr << "defined __FFLASFFPACK_FTRTRI_THRESHOLD to " << nbest << "" << std::endl;
+		std::cout << "#endif" << endl  << endl;
 	}
 	FFLAS::fflas_delete(T);
 	FFLAS::fflas_delete(U);

--- a/autotune/pluq.C
+++ b/autotune/pluq.C
@@ -66,15 +66,15 @@ int main () {
 	FFPACK::RandomMatrix (F, nmax, nmax, A,nmax);
 	FFLAS::fassign (F, nmax,nmax, A, nmax, B, nmax);
 	time_t result = std::time(NULL);
-	cout << std::endl 
+	cerr << std::endl 
 		  << "---------------------------------------------------------------------"
 		  << std::endl << std::asctime(std::localtime(&result))
 		  << std::endl
 		  << "Threshold for PLUQ base case" ;
-	F.write(cout << " (using ") << ')' << endl << endl;
+	F.write(cerr << " (using ") << ')' << endl << endl;
 
-	cout << "PLUQ:  n                   Base case                        Recursive 1 level" << std::endl;
-	cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+	cerr << "PLUQ:  n                   Base case                        Recursive 1 level" << std::endl;
+	cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
 		do {
 		double BCTime, RecTime;
 		int iter=10;
@@ -104,20 +104,20 @@ int main () {
 			//FFLAS::fflas_delete(B);
 		RecTime = tim.realtime()/iter;
 
-		cout << "      ";
-		cout.width(4);
-		cout << n;
-		cout << "  ";
-		cout.width(15);
-		cout << BCTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n,n,r, BCTime) << "  ";
-		cout.width(15);
-		cout << RecTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n,n,r, RecTime) << endl;
+		cerr << "      ";
+		cerr.width(4);
+		cerr << n;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << BCTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n,n,r, BCTime) << "  ";
+		cerr.width(15);
+		cerr << RecTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n,n,r, RecTime) << endl;
 
 		if (BCTime > RecTime){
 			count++;
@@ -136,12 +136,12 @@ int main () {
 		}
 	} while ((prec > 4 ) && (n < nmax));
 
-	cout<<endl;
+	cerr<<endl;
 	if (nbest != 0 ) {
-		cerr << "#ifndef __FFLASFFPACK_PLUQ_THRESHOLD"  << endl;
-		cerr << "#define __FFLASFFPACK_PLUQ_THRESHOLD" << ' ' <<  nbest << endl;
-		cout << "defined __FFLASFFPACK_PLUQ_THRESHOLD to " << nbest << "" << std::endl;
-		std::cerr << "#endif" << endl  << endl;
+		cout << "#ifndef __FFLASFFPACK_PLUQ_THRESHOLD"  << endl;
+		cout << "#define __FFLASFFPACK_PLUQ_THRESHOLD" << ' ' <<  nbest << endl;
+		cerr << "defined __FFLASFFPACK_PLUQ_THRESHOLD to " << nbest << "" << std::endl;
+		std::cout << "#endif" << endl  << endl;
 	}
 	FFLAS::fflas_delete(A);
 	FFLAS::fflas_delete(B);

--- a/autotune/tune_charpoly.sh
+++ b/autotune/tune_charpoly.sh
@@ -3,6 +3,8 @@ echo =================================================
 echo ========= FFLAS-FFPACK CharPoly Autotuning =========
 echo =================================================
 echo 
-./charpoly-LUK-ArithProg 2> charpoly-LUK-ArithProg-threshold.h  | tee charpoly-LUK-ArithProg-autotune.log
-./charpoly-Danilevskii-LUK 2> charpoly-Danilevskii-LUK-threshold.h  | tee charpoly-Danilevskii-LUK-autotune.log
-./arithprog 8 160 4 4 1000 3 2> arithprog-blocksize.h  | tee arithprog-blocksize-autotune.log
+(./charpoly-LUK-ArithProg > charpoly-LUK-ArithProg-threshold.h) 2>&1 | tee charpoly-LUK-ArithProg-autotune.log
+
+(./charpoly-Danilevskii-LUK > charpoly-Danilevskii-LUK-threshold.h) 2>&1 | tee charpoly-Danilevskii-LUK-autotune.log
+
+(./arithprog 8 160 4 4 1000 3 > arithprog-blocksize.h) 2>&1 | tee arithprog-blocksize-autotune.log

--- a/autotune/tune_fgemm.sh
+++ b/autotune/tune_fgemm.sh
@@ -4,13 +4,13 @@ echo ========= FFLAS-FFPACK fgemm Autotuning =========
 echo =================================================
 echo 
 echo "== Tuning fgemm over Modular<double> =="
-./winograd-modular-double 2> fgemm-thresholds.h  | tee fgemm-autotune.log
+(./winograd-modular-double > fgemm-thresholds.h) 2>&1 | tee fgemm-autotune.log
 echo 
 echo "== Tuning fgemm over Modular<float> =="
-./winograd-modular-float 2>>  fgemm-thresholds.h  | tee -a fgemm-autotune.log
+(./winograd-modular-float >>  fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log
 echo 
 echo "== Tuning fgemm over ModularBalanced<double> =="
-./winograd-modularbalanced-double 2>> fgemm-thresholds.h  | tee -a fgemm-autotune.log
+(./winograd-modularbalanced-double >> fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log
 echo 
 echo "== Tuning fgemm over ModularBalanced<float> =="
-./winograd-modularbalanced-float 2>>  fgemm-thresholds.h  | tee -a fgemm-autotune.log
+(./winograd-modularbalanced-float >>  fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log

--- a/autotune/tune_fsyrk.sh
+++ b/autotune/tune_fsyrk.sh
@@ -3,4 +3,4 @@ echo =================================================
 echo ========= FFLAS-FFPACK fsyrk Autotuning =========
 echo =================================================
 echo 
-./fsyrk 2> fsyrk-threshold.h  | tee fsyrk-autotune.log
+(./fsyrk > fsyrk-threshold.h) 2>&1 | tee fsyrk-autotune.log

--- a/autotune/tune_fsytrf.sh
+++ b/autotune/tune_fsytrf.sh
@@ -3,4 +3,4 @@ echo =================================================
 echo ========= FFLAS-FFPACK fsytrf Autotuning ========
 echo =================================================
 echo 
-./fsytrf 2> fsytrf-threshold.h  | tee fsytrf-autotune.log
+(./fsytrf > fsytrf-threshold.h) 2>&1 | tee fsytrf-autotune.log

--- a/autotune/tune_ftrtri.sh
+++ b/autotune/tune_ftrtri.sh
@@ -3,4 +3,4 @@ echo =================================================
 echo ========= FFLAS-FFPACK ftrtri Autotuning ========
 echo =================================================
 echo 
-./ftrtri 2> ftrtri-threshold.h  | tee ftrtri-autotune.log
+(./ftrtri > ftrtri-threshold.h) 2>&1 | tee ftrtri-autotune.log

--- a/autotune/tune_pluq.sh
+++ b/autotune/tune_pluq.sh
@@ -3,4 +3,4 @@ echo =================================================
 echo ========= FFLAS-FFPACK PLUQ Autotuning ==========
 echo =================================================
 echo 
-./pluq 2> pluq-threshold.h  | tee pluq-autotune.log
+(./pluq > pluq-threshold.h) 2>&1 | tee pluq-autotune.log

--- a/autotune/winograd.C
+++ b/autotune/winograd.C
@@ -80,15 +80,15 @@ int main () {
 	FFPACK::RandomMatrix (F, nmax, nmax, C, nmax);
 
 	time_t result = std::time(NULL);
-	cout << std::endl 
+	cerr << std::endl 
 		  << "---------------------------------------------------------------------"
 		  << std::endl << std::asctime(std::localtime(&result))
 		  << std::endl
 		  << "Threshold for finite field Strassen-Winograd matrix multiplication" ;
-	F.write(cout << " (using ") << ')' << endl << endl;
+	F.write(cerr << " (using ") << ')' << endl << endl;
 
-	cout << "fgemm:  n                   Classic                        Winograd 1 level" << std::endl;
-	cout << "                    seconds            Gfops          seconds            Gfops" << std::endl;
+	cerr << "fgemm:  n                   Classic                        Winograd 1 level" << std::endl;
+	cerr << "                    seconds            Gfops          seconds            Gfops" << std::endl;
 	FFLAS::MMHelper<Field, FFLAS::MMHelperAlgo::Winograd> ClassicH(F,0, FFLAS::ParSeqHelper::Sequential());
 	FFLAS::MMHelper<Field, FFLAS::MMHelperAlgo::Winograd> WinogradH(F,1, FFLAS::ParSeqHelper::Sequential());
 	    //warm up computation
@@ -111,20 +111,20 @@ int main () {
 		
 		winogradTime = chrono.realtime()/iter;
 
-		cout << "      ";
-		cout.width(4);
-		cout << n;
-		cout << "  ";
-		cout.width(15);
-		cout << classicTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n, classicTime) << "  ";
-		cout.width(15);
-		cout << winogradTime;
-		cout << "  ";
-		cout.width(15);
-		cout << GFOPS(n, winogradTime) << endl;
+		cerr << "      ";
+		cerr.width(4);
+		cerr << n;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << classicTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n, classicTime) << "  ";
+		cerr.width(15);
+		cerr << winogradTime;
+		cerr << "  ";
+		cerr.width(15);
+		cerr << GFOPS(n, winogradTime) << endl;
 
 		if (classicTime > winogradTime ){
 			count++;
@@ -143,36 +143,36 @@ int main () {
 		}
 	} while ((prec > 32 ) && (n < nmax));
 
-	cout<<endl;
+	cerr<<endl;
 	if (nbest != 0 ) {
 		if (typeid(Element).name() == typeid(double).name()) {
 			if ( balanced(F) ) {
-				cerr << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_BAL"  << endl;
-				cerr << "#define __FFLASFFPACK_WINOTHRESHOLD_BAL" << ' ' <<  nbest << endl;
-				cout << "defined __FFLASFFPACK_WINOTHRESHOLD_BAL to " << nbest << "" << std::endl;
+				cout << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_BAL"  << endl;
+				cout << "#define __FFLASFFPACK_WINOTHRESHOLD_BAL" << ' ' <<  nbest << endl;
+				cerr << "defined __FFLASFFPACK_WINOTHRESHOLD_BAL to " << nbest << "" << std::endl;
 		}
 			else {
-				cerr << "#ifndef __FFLASFFPACK_WINOTHRESHOLD"  << endl;
-				cerr << "#define __FFLASFFPACK_WINOTHRESHOLD" << ' ' <<  nbest << endl;
-				cout << "defined __FFLASFFPACK_WINOTHRESHOLD to " << nbest << "" << std::endl;
+				cout << "#ifndef __FFLASFFPACK_WINOTHRESHOLD"  << endl;
+				cout << "#define __FFLASFFPACK_WINOTHRESHOLD" << ' ' <<  nbest << endl;
+				cerr << "defined __FFLASFFPACK_WINOTHRESHOLD to " << nbest << "" << std::endl;
 	
 			}
-			std::cerr << "#endif" << endl  << endl;
+			std::cout << "#endif" << endl  << endl;
 		}
 		
 		if (typeid(Element).name() == typeid(float).name()) {
 			if ( balanced(F) ) {
-				cerr << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT"  << endl;
-				cerr << "#define __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT" << ' ' << nbest << endl;
-				cout << "defined __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT to " << nbest << "" << std::endl;
+				cout << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT"  << endl;
+				cout << "#define __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT" << ' ' << nbest << endl;
+				cerr << "defined __FFLASFFPACK_WINOTHRESHOLD_BAL_FLT to " << nbest << "" << std::endl;
 
 			}
 			else {
-				cerr << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_FLT"  << endl;
-				cerr << "#define __FFLASFFPACK_WINOTHRESHOLD_FLT" << ' ' << nbest << endl;
-				cout << "defined __FFLASFFPACK_WINOTHRESHOLD_FLT to " << nbest << "" << std::endl;
+				cout << "#ifndef __FFLASFFPACK_WINOTHRESHOLD_FLT"  << endl;
+				cout << "#define __FFLASFFPACK_WINOTHRESHOLD_FLT" << ' ' << nbest << endl;
+				cerr << "defined __FFLASFFPACK_WINOTHRESHOLD_FLT to " << nbest << "" << std::endl;
 			}
-			cerr << "#endif" << endl << endl;
+			cout << "#endif" << endl << endl;
 		}
 	}
 


### PR DESCRIPTION
That way unwanted warnings are not added to the .h
