### PR TITLE
Remove Bash-ism in fflas configure scripts

### DIFF
--- a/macros/config-header.m4
+++ b/macros/config-header.m4
@@ -66,24 +66,24 @@ else
   fi fi
   AC_MSG_NOTICE(creating $_OUT - prefix $_UPP for $_INP defines)
   if test -f $_INP ; then
-    echo "s/@%:@undef  *\\(@<:@m4_cr_LETTERS[]_@:>@\\)/@%:@undef $_UPP""_\\1/" > _script
-    echo "s/@%:@undef  *\\(@<:@m4_cr_letters@:>@\\)/@%:@undef $_LOW""_\\1/" >> _script
-    echo "s/@%:@def[]ine  *\\(@<:@m4_cr_LETTERS[]_@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_UPP""_\\1 \\" >> _script
-    echo "@%:@def[]ine $_UPP""_\\1 \\2 \\" >> _script
-    echo "@%:@endif/" >>_script
-    echo "s/@%:@def[]ine  *\\(@<:@m4_cr_letters@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_LOW""_\\1 \\" >> _script
-    echo "@%:@define $_LOW""_\\1 \\2 \\" >> _script
-    echo "@%:@endif/" >> _script
+    AS_ECHO("s/@%:@undef  *\\(@<:@m4_cr_LETTERS[]_@:>@\\)/@%:@undef $_UPP""_\\1/") > _script
+    AS_ECHO("s/@%:@undef  *\\(@<:@m4_cr_letters@:>@\\)/@%:@undef $_LOW""_\\1/") >> _script
+    AS_ECHO("s/@%:@def[]ine  *\\(@<:@m4_cr_LETTERS[]_@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_UPP""_\\1 \\") >> _script
+    AS_ECHO("@%:@def[]ine $_UPP""_\\1 \\2 \\") >> _script
+    AS_ECHO("@%:@endif/") >>_script
+    AS_ECHO("s/@%:@def[]ine  *\\(@<:@m4_cr_letters@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_LOW""_\\1 \\") >> _script
+    AS_ECHO("@%:@define $_LOW""_\\1 \\2 \\") >> _script
+    AS_ECHO("@%:@endif/") >> _script
     # now executing _script on _DEF input to create _OUT output file
-    echo "@%:@ifndef $_DEF"      >$tmp/pconfig.h
-    echo "@%:@def[]ine $_DEF 1" >>$tmp/pconfig.h
-    echo ' ' >>$tmp/pconfig.h
-    echo /'*' $_OUT. Generated automatically at end of configure. '*'/ >>$tmp/pconfig.h
+    AS_ECHO("@%:@ifndef $_DEF")      >$tmp/pconfig.h
+    AS_ECHO("@%:@def[]ine $_DEF 1") >>$tmp/pconfig.h
+    AS_ECHO(" ") >>$tmp/pconfig.h
+    AS_ECHO("/* $_OUT. Generated automatically at end of configure. */") >>$tmp/pconfig.h
 
     sed -f _script $_INP >>$tmp/pconfig.h
-    echo ' ' >>$tmp/pconfig.h
-    echo '/* once:' $_DEF '*/' >>$tmp/pconfig.h
-    echo "@%:@endif" >>$tmp/pconfig.h
+    AS_ECHO(" ") >>$tmp/pconfig.h
+    AS_ECHO("/* once: $_DEF */") >>$tmp/pconfig.h
+    AS_ECHO("@%:@endif") >>$tmp/pconfig.h
     if cmp -s $_OUT $tmp/pconfig.h 2>/dev/null; then
       AC_MSG_NOTICE([$_OUT is unchanged])
     else

--- a/macros/fflas-ffpack-blas.m4
+++ b/macros/fflas-ffpack-blas.m4
@@ -77,7 +77,7 @@ AC_DEFUN([FF_CHECK_USER_BLAS],
                                    ],[
                                      dnl No, then checking for  OpenBLAS
                                      BLAS_LIBS="${BLAS_LIBS} -lopenblas -lpthread"
-                                     AS_IF([ test  "x${CCNAM:0:3}" = "xgcc" ],[BLAS_LIBS="${BLAS_LIBS} -lgfortran"],[])
+                                     AS_CASE([$CCNAM], [gcc*], [BLAS_LIBS="${BLAS_LIBS} -lgfortran"])
                                      LIBS="${BACKUP_LIBS} ${BLAS_LIBS}"
 				     AC_TRY_RUN(
 					[ ${CODE_CBLAS} ],[

--- a/macros/fflas-ffpack-precompile.m4
+++ b/macros/fflas-ffpack-precompile.m4
@@ -32,8 +32,8 @@ AC_MSG_CHECKING([whether to compile the standard specializations])
 
 AC_ARG_ENABLE(precompilation,
 [AC_HELP_STRING([--enable-precompilation], [ Enable precompilation of the standard specializations])])
-AM_CONDITIONAL(FFLASFFPACK_PRECOMPILED, test "x$enable_precompilation" == "xyes")
-AS_IF([test "x$enable_precompilation" == "xyes"],
+AM_CONDITIONAL(FFLASFFPACK_PRECOMPILED, test "x$enable_precompilation" = "xyes")
+AS_IF([test "x$enable_precompilation" = "xyes"],
 	    [
 		AC_MSG_RESULT(yes)
 		PRECOMPILE_FLAGS="-DFFLAS_COMPILED -DFFPACK_COMPILED"


### PR DESCRIPTION
Patch by Gonzalo Tornaria to remove all bashism in givaro's configure scripts, making configure fail with dash-0.5.9.
See also https://trac.sagemath.org/ticket/23451