### PR TITLE
switched to vectorized broadcast in igemm_kernel, and added vectorization in igebb14

### DIFF
--- a/fflas-ffpack/fflas/fflas_igemm/igemm.inl
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm.inl
@@ -78,15 +78,13 @@ namespace FFLAS { namespace Protected {
 		FFLAS::details::BlockingFactor(mc,nc,kc);
 		size_t sizeA = mc*kc;
 		size_t sizeB = kc*cols;
-		size_t sizeW = simd::vect_size*kc*_nr; // store data duplicated by the number of elements fitting in vector register
 
 		// these data must be simd::alignment byte aligned
-		int64_t *blockA, *blockB, *blockW;
+		int64_t *blockA, *blockB;
 
 
 		blockA = fflas_new<int64_t>(sizeA, (Alignment)simd::alignment);
 		blockB = fflas_new<int64_t>(sizeB, (Alignment)simd::alignment);
-		blockW = fflas_new<int64_t>(sizeW, (Alignment)simd::alignment);
 
 		// For each horizontal panel of B, and corresponding vertical panel of A
 		for(size_t k2=0; k2<depth; k2+=kc){
@@ -117,14 +115,12 @@ namespace FFLAS { namespace Protected {
 				FFLAS::details::igebp<alpha_kind>(actual_mc, cols, actual_kc
 								  , alpha
 								  , blockA, actual_kc, blockB, actual_kc
-								  , C+i2, ldc
-								  , blockW);
+								  , C+i2, ldc);
 			}
 		}
 
 		fflas_delete(blockA);
 		fflas_delete(blockB);
-		fflas_delete(blockW);
 	}
 
 	void igemm( const enum FFLAS_TRANSPOSE TransA, const enum FFLAS_TRANSPOSE TransB,

--- a/fflas-ffpack/fflas/fflas_igemm/igemm_kernels.h
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm_kernels.h
@@ -89,8 +89,7 @@ namespace FFLAS { namespace details {
 		    , const int64_t alpha
 		    , const int64_t* blockA, size_t lda,
 		    const int64_t* blockB, size_t ldb,
-		    int64_t* C, size_t ldc,
-		    int64_t* blockW);
+		    int64_t* C, size_t ldc);
 
 } // details
 } // FFLAS

--- a/fflas-ffpack/fflas/fflas_igemm/igemm_kernels.inl
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm_kernels.inl
@@ -57,7 +57,8 @@ namespace FFLAS { namespace details { /*  kernels */
 	template<enum number_kind K>
 	inline void igebb44(size_t i, size_t j, size_t depth, size_t pdepth
 			    , const int64_t alpha
-			    , const int64_t *blA, const int64_t* blB
+			    , const int64_t *blA
+				, const int64_t *blB
 			    , int64_t* C, size_t ldc
 			   )
 	{
@@ -87,52 +88,52 @@ namespace FFLAS { namespace details { /*  kernels */
 			vect_t B_0,B_1,B_2,B_3;
 			A_0 = simd::load( blA+0*StepA);
 			A_1 = simd::load( blA+1*StepA);
-			B_0 = simd::load( blB+0*StepB);
-			B_1 = simd::load( blB+1*StepB);
+			B_0 = simd::set1( blB[0]);
+			B_1 = simd::set1( blB[1]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_2 = simd::load( blB+2*StepB);
+			B_2 = simd::set1( blB[2]);
 			simd::fmaddxin(C4,A_1,B_0); // B_0
-			B_3 = simd::load( blB+3*StepB);
-			B_0 = simd::load( blB+4*StepB);
+			B_3 = simd::set1( blB[3]);
+			B_0 = simd::set1( blB[4]);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C5,A_1,B_1); // B_1
-			B_1 = simd::load( blB+5*StepB);
+			B_1 = simd::set1( blB[5]);
 			simd::fmaddxin(C2,A_0,B_2);
 			simd::fmaddxin(C6,A_1,B_2); // B_2
-			B_2 = simd::load( blB+6*StepB);
+			B_2 = simd::set1( blB[6]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+2*StepA);
 			simd::fmaddxin(C7,A_1,B_3); // B_3
 			A_1 = simd::load( blA+3*StepA);
-			B_3 = simd::load( blB+7*StepB);
+			B_3 = simd::set1( blB[7]);
 			simd::fmaddxin(C0,A_0,B_0);
 			simd::fmaddxin(C4,A_1,B_0); // B_0
-			B_0 = simd::load( blB+8*StepB);
+			B_0 = simd::set1( blB[8]);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C5,A_1,B_1); // B_1
-			B_1 = simd::load( blB+9*StepB);
+			B_1 = simd::set1( blB[9]);
 			simd::fmaddxin(C2,A_0,B_2);
 			simd::fmaddxin(C6,A_1,B_2); // B_2
-			B_2 = simd::load( blB+10*StepB);
+			B_2 = simd::set1( blB[10]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+4*StepA);
 			simd::fmaddxin(C7,A_1,B_3); // B_3
 			A_1 = simd::load( blA+5*StepA);
-			B_3 = simd::load( blB+11*StepB);
+			B_3 = simd::set1( blB[11]);
 			simd::fmaddxin(C0,A_0,B_0);
 			simd::fmaddxin(C4,A_1,B_0); // B_0
-			B_0 = simd::load( blB+12*StepB);
+			B_0 = simd::set1( blB[12]);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C5,A_1,B_1); // B_1
-			B_1 = simd::load( blB+13*StepB);
+			B_1 = simd::set1( blB[13]);
 			simd::fmaddxin(C2,A_0,B_2);
 			simd::fmaddxin(C6,A_1,B_2); // B_2
-			B_2 = simd::load( blB+14*StepB);
+			B_2 = simd::set1( blB[14]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+6*StepA);
 			simd::fmaddxin(C7,A_1,B_3); // B_3
 			A_1 = simd::load( blA+7*StepA);
-			B_3 = simd::load( blB+15*StepB);
+			B_3 = simd::set1( blB[15]);
 			simd::fmaddxin(C0,A_0,B_0);
 			simd::fmaddxin(C4,A_1,B_0); // B_0
 			simd::fmaddxin(C1,A_0,B_1);
@@ -142,7 +143,7 @@ namespace FFLAS { namespace details { /*  kernels */
 			simd::fmaddxin(C3,A_0,B_3);
 			simd::fmaddxin(C7,A_1,B_3); // B_3
 			blA+= 8*StepA;
-			blB+=16*StepB;
+			blB+=16;
 		}
 		// process (depth mod 4) remaining entries by  (_mrx1) by (1x4) matrix mul
 		for(;k<depth;k++){
@@ -150,12 +151,12 @@ namespace FFLAS { namespace details { /*  kernels */
 			vect_t B_0,B_1,B_2,B_3;
 			A_0 = simd::load( blA+0*StepA);
 			A_1 = simd::load( blA+1*StepA);
-			B_0 = simd::load( blB+0*StepB);
-			B_1 = simd::load( blB+1*StepB);
+			B_0 = simd::set1( blB[0]);
+			B_1 = simd::set1( blB[1]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_2 = simd::load( blB+2*StepB);
+			B_2 = simd::set1( blB[2]);
 			simd::fmaddxin(C4,A_1,B_0); // B_0
-			B_3 = simd::load( blB+3*StepB);
+			B_3 = simd::set1( blB[3]);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C5,A_1,B_1);  // B_1
 			simd::fmaddxin(C2,A_0,B_2);
@@ -163,7 +164,7 @@ namespace FFLAS { namespace details { /*  kernels */
 			simd::fmaddxin(C3,A_0,B_3);
 			simd::fmaddxin(C7,A_1,B_3); // B_3
 			blA+=2*StepA;
-			blB+=4*StepB;
+			blB+=4;
 		}
 		vect_t R0, R1, R2, R3, R4, R5, R6;
 		vect_t A_0 ;
@@ -227,7 +228,8 @@ namespace FFLAS { namespace details { /*  kernels */
 	template<enum number_kind K>
 	inline void igebb24(size_t i, size_t j, size_t depth, size_t pdepth
 			    , const int64_t alpha
-			    , const int64_t *blA, const int64_t* blB
+			    , const int64_t *blA
+				, const int64_t* blB
 			    , int64_t* C, size_t ldc
 			   )
 	{
@@ -250,59 +252,59 @@ namespace FFLAS { namespace details { /*  kernels */
 			vect_t A_0;
 			vect_t B_0,B_1,B_2,B_3;
 			A_0 = simd::load( blA+0*StepA);
-			B_0 = simd::load( blB+0*StepB);
-			B_1 = simd::load( blB+1*StepB);
+			B_0 = simd::set1( blB[0]);
+			B_1 = simd::set1( blB[1]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_2 = simd::load( blB+2*StepB);
-			B_3 = simd::load( blB+3*StepB);
-			B_0 = simd::load( blB+4*StepB);
+			B_2 = simd::set1( blB[2]);
+			B_3 = simd::set1( blB[3]);
+			B_0 = simd::set1( blB[4]);
 			simd::fmaddxin(C1,A_0,B_1);
-			B_1 = simd::load( blB+5*StepB);
+			B_1 = simd::set1( blB[5]);
 			simd::fmaddxin(C2,A_0,B_2);
-			B_2 = simd::load( blB+6*StepB);
+			B_2 = simd::set1( blB[6]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+1*StepA);
-			B_3 = simd::load( blB+7*StepB);
+			B_3 = simd::set1( blB[7]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_0 = simd::load( blB+8*StepB);
+			B_0 = simd::set1( blB[8]);
 			simd::fmaddxin(C1,A_0,B_1);
-			B_1 = simd::load( blB+9*StepB);
+			B_1 = simd::set1( blB[9]);
 			simd::fmaddxin(C2,A_0,B_2);
-			B_2 = simd::load( blB+10*StepB);
+			B_2 = simd::set1( blB[10]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+2*StepA);
-			B_3 = simd::load( blB+11*StepB);
+			B_3 = simd::set1( blB[11]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_0 = simd::load( blB+12*StepB);
+			B_0 = simd::set1( blB[12]);
 			simd::fmaddxin(C1,A_0,B_1);
-			B_1 = simd::load( blB+13*StepB);
+			B_1 = simd::set1( blB[13]);
 			simd::fmaddxin(C2,A_0,B_2);
-			B_2 = simd::load( blB+14*StepB);
+			B_2 = simd::set1( blB[14]);
 			simd::fmaddxin(C3,A_0,B_3);
 			A_0 = simd::load( blA+3*StepA);
-			B_3 = simd::load( blB+15*StepB);
+			B_3 = simd::set1( blB[15]);
 			simd::fmaddxin(C0,A_0,B_0);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C2,A_0,B_2);
 			simd::fmaddxin(C3,A_0,B_3);
 			blA+= 4*StepA;
-			blB+=16*StepB;
+			blB+=16;
 		}
 		// process (depth mod 4) remaining entries by  (1/2_mrx1) by (1x4) matrix mul
 		for(;k<depth;k++){
 			vect_t A_0;
 			vect_t B_0,B_1,B_2,B_3;
 			A_0 = simd::load( blA+0*StepA);
-			B_0 = simd::load( blB+0*StepB);
-			B_1 = simd::load( blB+1*StepB);
+			B_0 = simd::set1( blB[0]);
+			B_1 = simd::set1( blB[1]);
 			simd::fmaddxin(C0,A_0,B_0);
-			B_2 = simd::load( blB+2*StepB);
-			B_3 = simd::load( blB+3*StepB);
+			B_2 = simd::set1( blB[2]);
+			B_3 = simd::set1( blB[3]);
 			simd::fmaddxin(C1,A_0,B_1);
 			simd::fmaddxin(C2,A_0,B_2);
 			simd::fmaddxin(C3,A_0,B_3);
 			blA+=StepA;
-			blB+=4*StepB;
+			blB+=4;
 		}
 		vect_t R0, R1, R2, R3;
 		vect_t A_0 ;
@@ -344,45 +346,88 @@ namespace FFLAS { namespace details { /*  kernels */
 			    , int64_t* C, size_t ldc
 			   )
 	{
-		// using simd = Simd<int64_t>;
-		// using vect_t =  typename simd::vect_t;
+		using simd = Simd<int64_t>;
+		using vect_t =  typename simd::vect_t;
 
 		size_t k;
 		int64_t *r0 = C+j*ldc+i;
 		int64_t *r1 = r0+ldc;
 		int64_t *r2 = r1+ldc;
 		int64_t *r3 = r2+ldc;
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+		vect_t R0;
+		R0 = simd::set(r0[0], r1[0], r2[0], r3[0]); // could be done with a gather (marginally faster?)
 		for(k=0;k<depth;k++){
+			vect_t A0;
+			vect_t B0;
+			B0 = simd::load(blB);
 			if (K == number_kind::one) {
-				r0[0]+=blA[0]*blB[0];
-				r1[0]+=blA[0]*blB[1];
-				r2[0]+=blA[0]*blB[2];
-				r3[0]+=blA[0]*blB[3];
+				A0 = simd::set1(blA[0]);
+				simd::fmaddxin(R0, A0, B0);
 			}
 			if (K == number_kind::mone) {
-				r0[0]-=blA[0]*blB[0];
-				r1[0]-=blA[0]*blB[1];
-				r2[0]-=blA[0]*blB[2];
-				r3[0]-=blA[0]*blB[3];
+				A0 = simd::set1(blA[0]);
+				simd::subin(R0,simd::mulx(A0, B0));
 			}
 			if (K == number_kind::other) {
 				int64_t abla = alpha*blA[0];
-				r0[0]+=abla*blB[0];
-				r1[0]+=abla*blB[1];
-				r2[0]+=abla*blB[2];
-				r3[0]+=abla*blB[3];
+				A0 = simd::set1(abla);
+				simd::fmaddxin(R0, A0, B0);
 			}
 
 			blA++;
 			blB+=4;
 		}
+		r0[0]     = simd::get(R0, 0);
+		r1[0]     = simd::get(R0, 1);
+		r2[0]     = simd::get(R0, 2);
+		r3[0]     = simd::get(R0, 3);
+#elif defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS) or defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
+		vect_t R0,R1;
+		R0 = simd::set(r0[0], r1[0]);
+		R1 = simd::set(r2[0], r3[0]);
+		for(k=0;k<depth;k++){
+			vect_t A0,A1;
+			vect_t B0,B1;
+			B0 = simd::load(blB+0*StepB);
+			B1 = simd::load(blB+1*StepB);
+			if (K == number_kind::one) {
+				A0 = simd::set1(blA[0]);
+				A1 = simd::set1(blA[0]);
+				simd::fmaddxin(R0, A0, B0);
+				simd::fmaddxin(R1, A1, B1);
+			}
+			if (K == number_kind::mone) {
+				A0 = simd::set1(blA[0]);
+				A1 = simd::set1(blA[0]);
+				simd::subin(R0,simd::mulx(A0, B0));
+				simd::subin(R1,simd::mulx(A1, B1));
+			}
+			if (K == number_kind::other) {
+				int64_t abla = alpha*blA[0];
+				A0 = simd::set1(abla);
+				A1 = simd::set1(abla);
+				simd::fmaddxin(R0, A0, B0);
+				simd::fmaddxin(R1, A1, B1);
+			}
+
+			blA++;
+			blB+=4;
+		}
+		r0[0] = simd::get(R0, 0);
+		r1[0] = simd::get(R0, 1);
+		r2[0] = simd::get(R1, 2);
+		r3[0] = simd::get(R1, 3);
+#endif
+
 	}
 
 
 	template<enum number_kind K>
 	inline void igebb41(size_t i, size_t j, size_t depth, size_t pdepth
 			    , const int64_t alpha
-			    , const int64_t *blA, const int64_t* blB
+			    , const int64_t *blA
+				, const int64_t* blB
 			    , int64_t* C, size_t ldc
 			   )
 	{
@@ -402,11 +447,11 @@ namespace FFLAS { namespace details { /*  kernels */
 			vect_t B_0;
 			A_0 = simd::load( blA+0*StepA);
 			A_1 = simd::load( blA+1*StepA);
-			B_0 = simd::load( blB+0*StepB);
+			B_0 = simd::set1( blB[0]);
 			simd::fmaddxin(C0,A_0,B_0);
 			simd::fmaddxin(C4,A_1,B_0); //! bug ,B_0 dans VEC_MADD_32 ?
 			blA+= 2*StepA;
-			blB+= 1*StepB;
+			blB+= 1;
 		}
 		vect_t R0, R4;
 		R0 = simd::loadu( r0);
@@ -433,7 +478,8 @@ namespace FFLAS { namespace details { /*  kernels */
 	template<enum number_kind K>
 	inline void igebb21(size_t i, size_t j, size_t depth, size_t pdepth
 			    , const int64_t alpha
-			    , const int64_t *blA, const int64_t* blB
+			    , const int64_t *blA
+				, const int64_t *blB
 			    , int64_t* C, size_t ldc
 			   )
 	{
@@ -450,10 +496,10 @@ namespace FFLAS { namespace details { /*  kernels */
 			vect_t A_0;
 			vect_t B_0;
 			A_0 = simd::load( blA+0*StepA);
-			B_0 = simd::load( blB+0*StepB);
+			B_0 = simd::set1( blB[0]);
 			simd::fmaddxin(C0,A_0,B_0);
 			blA+= 1*StepA;
-			blB+= 1*StepB;
+			blB+= 1;
 		}
 		vect_t R0;
 		vect_t A_0 ;
@@ -507,8 +553,7 @@ namespace FFLAS { namespace details { /*  main */
 		    , const int64_t alpha
 		    , const int64_t* blockA, size_t lda,
 		    const int64_t* blockB, size_t ldb,
-		    int64_t* C, size_t ldc,
-		    int64_t* blockW)
+		    int64_t* C, size_t ldc)
 	{
 		using simd = Simd<int64_t>;
 		// using vect_t =  typename simd::vect_t;
@@ -519,20 +564,18 @@ namespace FFLAS { namespace details { /*  main */
 		pdepth=(depth/4)*4;
 		// process columns by pack of _nr
 		for(j=0;j<pcols;j+=_nr){
-			duplicate_vect<simd::vect_size>(blockW, blockB+j*ldb,depth*_nr);
-			prefetch(blockW);
 			// process rows by pack of _mr
 			for (i=0;i<prows;i+=_mr){
 				const int64_t* blA = blockA+i*lda;
 				prefetch(blA);
-				igebb44<K>(i, j, depth, pdepth, alpha, blA, blockW, C, ldc);
+				igebb44<K>(i, j, depth, pdepth, alpha, blA, blockB+j*ldb, C, ldc);
 			}
 			i=prows;
 			// process the (rows%_mr) remainings rows
 			int rem=(int)(rows-prows);
 			while (rem >0) {
 				if (rem>=(int)simd::vect_size){
-					igebb24<K>(i  ,j,depth, pdepth, alpha , blockA+i*lda, blockW, C, ldc);
+					igebb24<K>(i  ,j,depth, pdepth, alpha , blockA+i*lda, blockB+j*ldb, C, ldc);
 					i+=simd::vect_size;
 					rem-=(int)simd::vect_size;
 				}
@@ -545,20 +588,18 @@ namespace FFLAS { namespace details { /*  main */
 		}
 		// process the (columns%_nr) remaining columns one by one
 		for (;j<cols;j++){
-                        duplicate_vect<simd::vect_size>(blockW, blockB+j*ldb,depth);
-			prefetch(blockW);
 			// process rows by pack of _mr
 			for (i=0;i<prows;i+=_mr){
 				const int64_t* blA = blockA+i*lda;
 				prefetch(blA);
-				igebb41<K>(i, j, depth, pdepth, alpha, blA, blockW, C, ldc);
+				igebb41<K>(i, j, depth, pdepth, alpha, blA, blockB+j*ldb, C, ldc);
 			}
 			i=prows;
 			// process the (rows%_mr) remainings rows
 			int rem=(int)(rows-prows);
 			while (rem >0) {
 				if (rem>=(int)simd::vect_size){
-					igebb21<K>(i  ,j,depth, pdepth, alpha, blockA+i*lda, blockW, C, ldc);
+					igebb21<K>(i  ,j,depth, pdepth, alpha, blockA+i*lda, blockB+j*ldb, C, ldc);
 					i+=simd::vect_size;
 					rem-=(int)(simd::vect_size);
 				}

--- a/fflas-ffpack/fflas/fflas_igemm/igemm_tools.h
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm_tools.h
@@ -37,10 +37,6 @@
 
 namespace FFLAS { namespace details { /*  tools */
 
-	// duplicate each entry into vector register
-	template<size_t N>
-	inline void duplicate_vect (int64_t* XX, const int64_t* X, size_t n){}
-
 	template<size_t k,bool transpose>
 	void pack_lhs(int64_t* XX, const int64_t* X, size_t ldx, size_t rows, size_t cols);
 

--- a/fflas-ffpack/fflas/fflas_igemm/igemm_tools.inl
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm_tools.inl
@@ -34,30 +34,6 @@
 
 namespace FFLAS { namespace details {
 
-	template<>
-	inline void duplicate_vect<2>(int64_t* XX, const int64_t* X, size_t n)
-	{
-		int64_t *p=XX;
-		for(size_t i=0;i<n;i++){
-			p[0]=X[i];
-			p[1]=X[i];
-			p+=2;
-		}
-	}
-
-	template<>
-	inline void duplicate_vect<4>(int64_t* XX, const int64_t* X, size_t n)
-	{
-		int64_t *p=XX;
-		for(size_t i=0;i<n;i++){
-			p[0]=X[i];
-			p[1]=X[i];
-			p[2]=X[i];
-			p[3]=X[i];
-			p+=4;
-		}
-	}
-
 	// store each rows x k submatrices of Rhs in row major mode
 	// if k does not divide cols, the remaining column are not packed
 	template<size_t k, bool transpose>

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -103,6 +103,14 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
 	}
 
 	/*
+	 *  Extract one 64-bit integer from src at *_immediate_* index idx
+	 *  Return v[idx] int64_t
+	 */
+	static INLINE CONST scalar_t get(vect_t v, const scalar_t idx) {
+		return _mm_extract_epi64(v, idx);
+	}
+
+	/*
 	* Load 128-bits of integer data from memory into dst.
 	* p must be aligned on a 16-byte boundary or a general-protection exception will be generated.
 	* Return [p[0],p[1]] int64_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -106,12 +106,22 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
 		return _mm256_set_epi64x(x3, x2, x1, x0);
 	}
 
+	//TODO use the real gather? (e.g. with _mm256_i64gather_epi64)
+	//But cannot with this signature...
 	/*
 	 *  Gather 64-bit integer elements with indexes idx[0], ..., idx[3] from the address p in vect_t.
 	 *  Return [p[idx[0]], p[idx[1]], p[idx[2]], p[idx[3]]] int64_t
 	 */
 	template <class T> static INLINE PURE vect_t gather(const scalar_t *const p, const T *const idx) {
 		return set(p[idx[0]], p[idx[1]], p[idx[2]], p[idx[3]]);
+	}
+
+	/*
+	 *  Extract one 64-bit integer from src at index idx
+	 *  Return v[idx] int64_t
+	 */
+	static INLINE CONST scalar_t get(vect_t v, const scalar_t idx) {
+		return _mm256_extract_epi64(v, idx);
 	}
 
 	/*


### PR DESCRIPTION
Replaced the duplictate_vect calls in igemm_kernel by more efficient set1 broadcast intrinsics.
This reduces memory consumption by making blockW redundant, and should altogether require less computations.
Vectorized most of igebb14, that previously was not.