### PR TITLE
Fixing #182

### DIFF
--- a/fflas-ffpack/fflas-ffpack-config.h
+++ b/fflas-ffpack/fflas-ffpack-config.h
@@ -150,7 +150,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
 /* Define if avx512dq instructions are supported */
 #ifdef __AVX512DQ__
-#define __FFLASFFPACK_HAVE_AVx512DQ_INSTRUCTIONS 1
+#define __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS 1
 #endif
 
 /* Define if fma instructions are supported */

--- a/fflas-ffpack/fflas/fflas_fadd.h
+++ b/fflas-ffpack/fflas/fflas_fadd.h
@@ -44,15 +44,11 @@ namespace FFLAS {
 	struct support_simd_add<double> : public std::true_type {} ;
 #ifdef SIMD_INT
 	template<>
+	struct support_simd_add<int32_t> : public std::true_type {} ;
+	template<>
 	struct support_simd_add<int64_t> : public std::true_type {} ;
 #endif // SIMD_INT
 #endif // __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
-
-#ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
-	    // no int32_t AVX512 implemented yet in FFLAS
-	template<>
-	struct support_simd_add<int32_t> : public std::true_type {} ;
-#endif // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
 
 } // FFLAS
 

--- a/fflas-ffpack/fflas/fflas_fadd.h
+++ b/fflas-ffpack/fflas/fflas_fadd.h
@@ -37,21 +37,22 @@ namespace FFLAS {
 	template<class T>
 	struct support_simd_add  : public std::false_type {} ;
 
-// #ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
 	template<>
 	struct support_simd_add<float> : public std::true_type {} ;
 	template<>
 	struct support_simd_add<double> : public std::true_type {} ;
+#ifdef SIMD_INT
 	template<>
 	struct support_simd_add<int64_t> : public std::true_type {} ;
+#endif // SIMD_INT
+#endif // __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
 
 #ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
 	    // no int32_t AVX512 implemented yet in FFLAS
 	template<>
 	struct support_simd_add<int32_t> : public std::true_type {} ;
-#endif
-
-// #endif // __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+#endif // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
 
 } // FFLAS
 

--- a/fflas-ffpack/fflas/fflas_fadd.inl
+++ b/fflas-ffpack/fflas/fflas_fadd.inl
@@ -34,7 +34,6 @@
 
 namespace FFLAS { namespace vectorised {
 
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
 
 	template<class SimdT, class Element, bool positive>
 	inline typename std::enable_if<is_simd<SimdT>::value, void>::type
@@ -283,51 +282,6 @@ namespace FFLAS { namespace vectorised {
 			T[i] = TA[i] - TB[i];
 		}
 	}
-#else // no simd, but faster than F.init()     // CP: is this necessary? subp and addp only called when support_simd_add is defined
-
-	// template<bool positive, class Element, class T1, class T2>
-	// // inline typename std::enable_if<!FFLAS::support_simd_add<Element>::value, void>::type
-	// void
-	// subp(Element * T, const Element * TA, const Element * TB, const size_t n, const Element p, const T1 min_, const T2 max_)
-	// {
-	// 	Element min = (Element)min_, max = (Element)max_;
-
-	// 	size_t i = 0;
-
-	// 		for (; i < n ; i++)
-	// 		{
-	// 			T[i] = TA[i] - TB[i];
-	// 			if (!positive)
-	// 				T[i] -= (T[i] > max) ? p : 0;
-	// 			T[i] += (T[i] < min) ? p : 0;
-	// 		}
-	// 		return;
-
-	// }
-
-	// template<bool positive, class Element, class T1, class T2>
-	// // inline typename std::enable_if<!FFLAS::support_simd_add<Element>::value, void>::type
-	// void
-	// addp(Element * T, const Element * TA, const Element * TB,  const size_t n,  const Element p,  const T1 min_,  const T2 max_)
-	// {
-	// 	Element min= (Element)min_, max= (Element)max_;
-
-	// 	size_t i = 0;
-
-	// 	for (; i < n ; i++)
-	// 	{
-	// 		T[i] = TA[i] + TB[i];
-	// 		T[i] -= (T[i] > max) ? p : 0;
-	// 		if (!positive)
-	// 		{
-	// 			T[i] += (T[i] < min) ? p : 0;
-	// 		}
-	// 	}
-	// 	return;
-	// }
-
-
-#endif // __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
 
 } // vectorised
 } //  FFLAS

--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -336,8 +336,10 @@ template <class T, bool b> struct SimdChooser<T, false, b> { using value = NoSim
 template <class T>
 struct SimdChooser<T, true, false> // floating number
 {
-#ifdef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
 	using value = Simd512<T>;
+#elif defined (__FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS)
+	using value = Simd256<T>;
 #elif defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 	using value = Simd256<T>;
 #elif defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -415,7 +415,7 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
 		return _mm512_maskz_expand_pd(_mm512_cmp_pd_mask(a, b, _CMP_GE_OS), _mm512_castsi512_pd(c)); 
 	}
 
-#ifdef __AVX512DQ__
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
 	/*
 	 * Compute the bitwise AND of packed double-precision (64-bit) floating-point elements in a and b, and store the
 	 * results in vect_t.
@@ -448,8 +448,8 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
 	 * ANDNOT b7]
 	 */
 	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm512_andnot_pd(a, b); }
-#else //AVX512DQ
-#endif
+#endif /* __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS */
+
 	/*
 	 * Round the packed double-precision (64-bit) floating-point elements in a down to an integer value, and store the
 	 * results as packed double-precision floating-point elements in vect_t.
@@ -511,6 +511,8 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
 				((const scalar_t *)&a)[6] + ((const scalar_t *)&a)[7];
 	}
 
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
+	/* Call NORML_MOD which needs vand which is not defined without AVX512DQ */
 	static INLINE vect_t mod(vect_t &C, const vect_t &P, const vect_t &INVP, const vect_t &NEGP, const vect_t &MIN,
 							 const vect_t &MAX, vect_t &Q, vect_t &T) {
 		FLOAT_MOD(C, P, INVP, Q);
@@ -518,6 +520,7 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
 
 		return C;
 	}
+#endif /* __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS */
 
 };
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -479,8 +479,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
 		return _mm512_maskz_expand_ps(_mm512_cmp_ps_mask(a, b, _CMP_GE_OS), _mm512_castsi512_ps(c)); 
 	} 
 
-#ifdef __AVX512DQ__
-
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
 	/*
 	 * Compute the bitwise AND of packed single-precision (32-bit) floating-point elements in a and b, and store the
 	 * results in vect_t.
@@ -521,9 +520,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
 	 *			a8 ANDNOT b8, a9 ANDNOT b9, a10 ANDNOT b10, a11 ANDNOT b11, a12 ANDNOT b12, a13 ANDNOT b13, a14 ANDNOT b14, a15 ANDNOT b15]
 	 */
 	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm512_andnot_ps(a, b); }
-#else //__AVX512DQ__
-
-#endif
+#endif /* __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS */
 	/*
 	 * Round the packed single-precision (32-bit) floating-point elements in a down to an integer value, and store the
 	 * results as packed double-precision floating-point elements in vect_t.
@@ -593,6 +590,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
 				((const scalar_t *)&a)[15];
 	}
 
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
+	/* Call NORML_MOD which needs vand which is not defined without AVX512DQ */
 	static INLINE vect_t mod(vect_t &C, const vect_t &P, const vect_t &INVP, const vect_t &NEGP, const vect_t &MIN,
 							 const vect_t &MAX, vect_t &Q, vect_t &T) {
 		FLOAT_MOD(C, P, INVP, Q);
@@ -600,6 +599,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
 
 		return C;
 	}
+#endif /* __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS */
 
 #else // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
 #error "You need AVX512 instructions to perform 512bits operations on float"

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -272,7 +272,7 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
 	*		   [a4, b4, a5, b5, a6, b6, a7, b7] int64_t
 	*/
 
-	static INLINE CONST void unpacklohi(vect_t& l, vect_t& h, const vect_t a, const vect_t b) {
+	static INLINE void unpacklohi(vect_t& l, vect_t& h, const vect_t a, const vect_t b) {
 		l = unpacklo(a, b);
 		h = unpackhi(a, b);
 	}


### PR DESCRIPTION
This commit fixes issue #182 which prevented fflas-ffpack to be compiled without some SIMD capabilities.

The problem was due to the fact that some code was protected with both a `#ifdef` and a `enable_if` (like `addp` in [fflas-ffpack/fflas/fflas_fadd.inl](../blob/master/fflas-ffpack/fflas/fflas_fadd.inl)). But during compilation, the compiler check that all symbols are defined. In the case where `__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS` is not defined, when the function `fadd` is compiled in the same file  the symbol `addp` is not defined. The compile prints an error even if the function `fadd` is never used (due to the `enable_if` in its definition).

There exist other files with the same construction ([fflas-ffpack/fflas/fflas_fscal.inl](../blob/master/fflas-ffpack/fflas/fflas_fscal.inl) for example). But there is no problem for those files as there are `#elif` clauses that define alternatives for the case where `__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS` is not defined. This PR may be an opportunity to remove this overprotective `#define` and keep only the `enable_if` scheme.

I am not completly sure that the changes I made in [fflas-ffpack/fflas/fflas_fadd.h](../blob/fix-issue182/fflas-ffpack/fflas/fflas_fadd.h) are correct as I am not sure about the meaning of the `SIMD_INT` macro. I looked at [fflas-ffpack/fflas/fflas_freduce.h](../blob/fix-issue182/fflas-ffpack/fflas/fflas_freduce.h) for inspiration.