### PR TITLE
Use __RECINT_LIMB_BITS instead of mp_limb_t in rns-double (fixing #155)

### DIFF
--- a/fflas-ffpack/field/rns-double-recint.inl
+++ b/fflas-ffpack/field/rns-double-recint.inl
@@ -66,13 +66,11 @@ namespace FFPACK {
 					  size_t l=0;
 					  size_t maxs=std::min(k,size_t(1UL<<(K-4)));
 					  
-					  //size_t maxs=std::min(k,(Aiter[j+i*lda].size())*sizeof(mp_limb_t)/2);// to ensure 32 bits portability
-
 					  for (;l<maxs;l++){
 #ifdef __FFLASFFPACK_HAVE_LITTLE_ENDIAN
 						  A_beta[l+idx*k]= m0_ptr[l];						  
 #else
-						  A_beta[l+idx*k]= m0_ptr[l^((sizeof(mp_limb_t)/2U)-1U)];
+						  A_beta[l+idx*k]= m0_ptr[l^((__RECINT_LIMB_BITS/16U)-1U)]; /* big endian: from __RECINT_LIMB_BITS-bit word to 16-bit words */
 #endif
 					  }
 					  for (;l<k;l++)


### PR DESCRIPTION
On big endian architecture with 32 bits, the code of RNS double was buggy as it assumed that recint was using words of length `8*mp_limb_t` bits (32 on 32-bit machine) instead of RECINT_LIMB_BITS bits (which is always 64).
This fix `test-fgemm` and `test-fgemv` that failed on those architectures (see #155).