### PR TITLE
Avoid using Simd64 on 32 bit machines

### DIFF
--- a/fflas-ffpack/fflas/fflas_fgemm/fgemm_classical.inl
+++ b/fflas-ffpack/fflas/fflas_fgemm/fgemm_classical.inl
@@ -39,7 +39,7 @@
 #include <cmath>
 
 #include "fflas-ffpack/field/field-traits.h"
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+#if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS) and defined(__x86_64__)
 #include "fflas-ffpack/fflas/fflas_igemm/igemm.h"
 #endif
 
@@ -297,7 +297,7 @@ namespace FFLAS {
 		FFLASFFPACK_check(ldb);
 		FFLASFFPACK_check(ldc);
 		
-#if defined (__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
+#if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS) and defined(__x86_64__)
 		igemm_ (FflasRowMajor, ta, tb, (int)m, (int)n, (int)k, alpha, Ad, (int)lda, Bd, (int)ldb, beta, Cd, (int)ldc);
 #else
 		for (size_t i=0; i<m; i++){

--- a/fflas-ffpack/fflas/fflas_fgemv.inl
+++ b/fflas-ffpack/fflas/fflas_fgemv.inl
@@ -33,7 +33,7 @@
 
 #include <givaro/zring.h> // DoubleDomain
 
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+#if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS) and defined(__x86_64__)
 #include "fflas-ffpack/fflas/fflas_igemm/igemm.h"
 #endif
 
@@ -379,7 +379,7 @@ namespace FFLAS{
 	{
 		FFLASFFPACK_check(lda);
 
-#if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
+#if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS) and defined(__x86_64__)
 		if (ta == FflasNoTrans)
 			igemm_ (FflasRowMajor, ta, FflasNoTrans,M,1,N,alpha,A,lda,X,incX,beta,Y,incY);
 		else

--- a/fflas-ffpack/fflas/fflas_igemm/igemm.h
+++ b/fflas-ffpack/fflas/fflas_igemm/igemm.h
@@ -41,10 +41,8 @@ namespace FFLAS {
 
 } // FFLAS
 
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
 #include "igemm_kernels.h"
 #include "igemm_tools.h"
-#endif 
 #include "fflas-ffpack/utils/fflas_memory.h"
 
 namespace FFLAS { namespace Protected {
@@ -89,8 +87,7 @@ namespace FFLAS { /*  igemm */
 
 
 } // FFLAS
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+
 #include "igemm.inl"
-#endif
 #endif // __FFLASFFPACK_fflas_igemm_igemm_H
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128.inl
@@ -107,8 +107,9 @@ Simd128_impl<std::is_arithmetic<T>::value, std::is_integral<T>::value, std::is_s
 
 #include "simd128_int16.inl"
 #include "simd128_int32.inl"
+#ifdef __x86_64__
 #include "simd128_int64.inl"
-
+#endif
 #endif //#ifdef SIMD_INT
 
 #endif // __FFLASFFPACK_fflas_ffpack_utils_simd128_INL

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -35,7 +35,9 @@
 #error "You need SSE instructions to perform 128 bits operations on int32"
 #endif
 
+#ifdef __x86_64__
 #include "fflas-ffpack/fflas/fflas_simd/simd128_int64.inl"
+#endif
 
 /*
  * Simd128 specialized for int32_t
@@ -252,7 +254,7 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		// _mm_mulhi_epi32 emul
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#if 0
+#ifdef __x86_64__
 		vect_t a1, a2, b1, b2;
 		a1 = set(_mm_extract_epi32(a, 0), 0, _mm_extract_epi32(a, 2), 0);
 		a2 = set(_mm_extract_epi32(a, 1), 0, _mm_extract_epi32(a, 3), 0);

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -254,7 +254,7 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		// _mm_mulhi_epi32 emul
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#ifdef __x86_64__
+#ifndef __x86_64__
 		vect_t a1, a2, b1, b2;
 		a1 = set(_mm_extract_epi32(a, 0), 0, _mm_extract_epi32(a, 2), 0);
 		a2 = set(_mm_extract_epi32(a, 1), 0, _mm_extract_epi32(a, 3), 0);

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -183,7 +183,9 @@ using Simd256 =
 // To many missing insctructions on int8_t
 
 #if defined(__FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS)
+#ifdef __x86_64__
 #include "simd256_int64.inl"
+#endif
 #include "simd256_int32.inl"
 #include "simd256_int16.inl"
 #endif

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -229,10 +229,14 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
 	* Return :	[a0, b0, ..., a7, b7] int16_t
 	*/
 	static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// using Simd256_64 = Simd256<uint64_t>;
+		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
+		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// return unpacklo_twice(a1, b1);
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		return unpacklo_twice(a1, b1);
+
 	}
 
 	/*
@@ -242,10 +246,14 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
 	* Return :	[a8, b8, ..., a15, b15] int16_t
 	*/
 	static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// using Simd256_64 = Simd256<uint64_t>;
+		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
+		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// return unpackhi_twice(a1, b1);
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		return unpackhi_twice(a1, b1);
+
 	}
 
 	/*
@@ -256,11 +264,14 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
 	*			[a8, b8, ..., a15, b15] int16_t
 	*/
 	static INLINE void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// using Simd256_64 = Simd256<uint64_t>;
+		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
+		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		s1 = unpacklo_twice(a1, b1);
 		s2 = unpackhi_twice(a1, b1);
+
 	}
 
 	/*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -231,7 +231,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	* Return :	[a0, b0, ..., a3, b3] int32_t
 	*/
 	static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
+			//using Simd256_64 = Simd256<uint64_t>;
 			//Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
 			//Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
 		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -244,7 +244,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	* Return :	[a4, b4, ..., a7, b7] int32_t
 	*/
 	static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
+		// using Simd256_64 = Simd256<uint64_t>;
 		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
 		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
 		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
@@ -260,7 +260,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*			[a4, b4, ..., a7, b7] int32_t
 	*/
 	static INLINE void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
-		using Simd256_64 = Simd256<uint64_t>;
+		// using Simd256_64 = Simd256<uint64_t>;
 		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
 		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
 		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
@@ -321,7 +321,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#ifdef 0
+#ifdef __x86_64__
 		typedef Simd256_impl<true, true, true, 8> Simd256_64;
 		Converter ca, cb;
 		ca.v = a;

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -323,7 +323,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#ifndef __x86_64__
+#if 0
 		typedef Simd256_impl<true, true, true, 8> Simd256_64;
 		Converter ca, cb;
 		ca.v = a;
@@ -333,22 +333,30 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 		a2 = set(ca.t[4], 0, ca.t[5], 0, ca.t[6], 0, ca.t[7], 0);
 		b1 = set(cb.t[0], 0, cb.t[1], 0, cb.t[2], 0, cb.t[3], 0);
 		b2 = set(cb.t[4], 0, cb.t[5], 0, cb.t[6], 0, cb.t[7], 0);
-		c1 = Simd256_64::mulx(a1, b1);
-		c2 = Simd256_64::mulx(a2, b2);
+		c1 = _mm256_mul_epi32(a1, b1); //Simd256_64::mulx(a1, b1);
+		c2 = _mm256_mul_epi32(a1, b2); //Simd256_64::mulx(a2, b2);
 		ca.v = c1;
 		cb.v = c2;
 		return set(ca.t[1], ca.t[3], ca.t[5], ca.t[7], cb.t[1], cb.t[3], cb.t[5], cb.t[7]);
 #else
-		typedef Simd256_impl<true, true, true, 8> Simd256_64;
+			//typedef Simd256_impl<true, true, true, 8> Simd256_64;
 		vect_t C,A1,B1;
-		C  = Simd256_64::mulx(a,b);
-		A1 = Simd256_64::srl(a,32);
-		B1 = Simd256_64::srl(b,32);
-		A1 = Simd256_64::mulx(A1,B1);
-		C  = Simd256_64::srl(C,32);
-		A1 = Simd256_64::srl(A1,32);
-		A1 = Simd256_64::sll(A1,32);
-		return Simd256_64::vor(C,A1);
+			//C  = Simd256_64::mulx(a,b);
+		C  = _mm256_mul_epi32(a,b);
+			//A1 = Simd256_64::srl(a,32);
+		A1 = _mm256_srli_epi64(a, 32);
+			//B1 = Simd256_64::srl(b,32);
+		B1 = _mm256_srli_epi64(b, 32);
+			//A1 = Simd256_64::mulx(A1,B1);
+		A1 =  _mm256_mul_epi32(A1,B1);
+			//C  = Simd256_64::srl(C,32);
+		C  = _mm256_srli_epi64(C, 32);
+			//A1 = Simd256_64::srl(A1,32);
+		A1 = _mm256_srli_epi64(A1, 32);
+			//A1 = Simd256_64::sll(A1,32);
+		A1 = _mm256_slli_epi64(A1, 32);
+			//return Simd256_64::vor(C,A1);
+		return _mm256_or_si256(A1, C);
 #endif
 	}
 
@@ -662,17 +670,34 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
 	* Return : [Floor(a0*b0/2^32), ..., Floor(a7*b7/2^32)] uint32_t
 	*/
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
-		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-		typedef Simd256_impl<true, true, false, 8> Simd256_64;
+		// //#pragma warning "The simd mulhi function is emulated, it may impact the performances."
+		// typedef Simd256_impl<true, true, false, 8> Simd256_64;
+		// vect_t C,A1,B1;
+		// C  = Simd256_64::mulx(a,b);
+		// A1 = Simd256_64::srl(a,32);
+		// B1 = Simd256_64::srl(b,32);
+		// A1 = Simd256_64::mulx(A1,B1);
+		// C  = Simd256_64::srl(C,32);
+		// A1 = Simd256_64::srl(A1,32);
+		// A1 = Simd256_64::sll(A1,32);
+		// return Simd256_64::vor(C,A1);
 		vect_t C,A1,B1;
-		C  = Simd256_64::mulx(a,b);
-		A1 = Simd256_64::srl(a,32);
-		B1 = Simd256_64::srl(b,32);
-		A1 = Simd256_64::mulx(A1,B1);
-		C  = Simd256_64::srl(C,32);
-		A1 = Simd256_64::srl(A1,32);
-		A1 = Simd256_64::sll(A1,32);
-		return Simd256_64::vor(C,A1);
+			//C  = Simd256_64::mulx(a,b);
+		C  = _mm256_mul_epi32(a,b);
+			//A1 = Simd256_64::srl(a,32);
+		A1 = _mm256_srli_epi64(a, 32);
+			//B1 = Simd256_64::srl(b,32);
+		B1 = _mm256_srli_epi64(b, 32);
+			//A1 = Simd256_64::mulx(A1,B1);
+		A1 =  _mm256_mul_epi32(A1,B1);
+			//C  = Simd256_64::srl(C,32);
+		C  = _mm256_srli_epi64(C, 32);
+			//A1 = Simd256_64::srl(A1,32);
+		A1 = _mm256_srli_epi64(A1, 32);
+			//A1 = Simd256_64::sll(A1,32);
+		A1 = _mm256_slli_epi64(A1, 32);
+			//return Simd256_64::vor(C,A1);
+		return _mm256_or_si256(A1, C);
 	}
 
 	/*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -35,7 +35,9 @@
 #error "You need AVX2 instructions to perform 256bits operations on int32_t"
 #endif
 
+#ifdef __x86_64__
 #include "fflas-ffpack/fflas/fflas_simd/simd256_int64.inl"
+#endif
 
 /*
  * Simd256 specialized for int32_t
@@ -321,7 +323,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#ifdef __x86_64__
+#ifndef __x86_64__
 		typedef Simd256_impl<true, true, true, 8> Simd256_64;
 		Converter ca, cb;
 		ca.v = a;

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -230,8 +230,10 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
 		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+			//Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
+			//Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		return unpacklo_twice(a1, b1);
 	}
 
@@ -243,8 +245,10 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
 		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
+		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		return unpackhi_twice(a1, b1);
 	}
 
@@ -257,8 +261,10 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
 		using Simd256_64 = Simd256<uint64_t>;
-		vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-		vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		// vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
+		// vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
+		vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
+		vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
 		s1 = unpacklo_twice(a1, b1);
 		s2 = unpackhi_twice(a1, b1);
 	}
@@ -315,7 +321,7 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
 	*/
 	static INLINE CONST vect_t mulhi(const vect_t a, const vect_t b) {
 		//#pragma warning "The simd mulhi function is emulated, it may impact the performances."
-#if 0
+#ifdef 0
 		typedef Simd256_impl<true, true, true, 8> Simd256_64;
 		Converter ca, cb;
 		ca.v = a;


### PR DESCRIPTION
Fixes #195 
Reason: some intinsic defined for simd{128,256}_64 are only defined on a 64 bit system. Previous code used to implement the whole simd64 class to make some specific calls.
This PR
* makes these calls directly when they are still defined on a 32 bit system
* emulates the function when it is possible
* disables igemm on 32 bit machines since it's heavily based on simd64 intrinsics
