### PR TITLE
Fix calls to andnot intrinsics so vandnot functions have the same behavior

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128.inl
@@ -89,7 +89,7 @@ struct Simd128i_base {
 	*		   [b0, ..., b127]
 	* Return : [NOT(a0) AND b0, ..., NOT(a127) AND b127]
 	*/
-	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm_andnot_si128(b, a); }
+	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm_andnot_si128(a, b); }
 
 };
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -139,7 +139,7 @@ struct Simd256i_base {
 	*		   [b0, ..., b255]
 	* Return : [(NOT a0) AND b0, ..., (NOT a255) AND b255]
 	*/
-	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm256_andnot_si256(b, a); }
+	static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm256_andnot_si256(a, b); }
 
 	/*
 	* Shuffle 128-bit integers in a and b using the control in imm8, and store the results in dst.


### PR DESCRIPTION
Fixing  problems introduced by PR #196: the `vandnot` functions were calling the `andnot` intrinsics as `f(a,b)` for floating point type and as `f(b,a)` for integral type.