### PR TITLE
Make parameter of printCommandString a 'const char *' to avoid warning

### DIFF
--- a/fflas-ffpack/utils/args-parser.h
+++ b/fflas-ffpack/utils/args-parser.h
@@ -330,7 +330,7 @@ namespace FFLAS {
     }
 
 	/** writes the values of all arguments, preceded by the programName */
-	std::ostream& writeCommandString (std::ostream& os, Argument *args, char* programName = nullptr)
+	std::ostream& writeCommandString (std::ostream& os, Argument *args, const char* programName = nullptr)
 	{
 		if (programName != nullptr)
 			os << programName;


### PR DESCRIPTION
This change avoid the warning 
> ISO C++ forbids converting a string constant to ‘char*’

when calling printCommandString with a string constant
```cpp
printCommandString (std::cout, args, "program");
``` 