### PR TITLE
Fix test-simd.C

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -174,14 +174,14 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      */
     template<int s>
     static INLINE CONST vect_t sra(const vect_t a) {
-#ifdef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#if defined(__FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS) and defined(__FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS)
         return _mm_srai_epi64(a, s);
 #else
         vect_t m = sll<63-s>(set1(1));
         vect_t x = srl<s>(a);
         vect_t result = sub(vxor(x, m), m); // result = x^m - m
         return result;
-#endif // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#endif // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS and __FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS
     }
 
     /*
@@ -255,7 +255,7 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      *	   where (a smod p) is the signed representant of a modulo p, that is -p/2 <= (a smod p) < p/2
      */
     static INLINE CONST vect_t mullo(const vect_t x0, const vect_t x1) {
-#ifdef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#if defined(__FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS) and defined(__FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS)
         return _mm_mullo_epi64(x0, x1);
 #else
         // _mm_mullo_epi64 emul
@@ -264,7 +264,7 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
         c0.v = x0;
         c1.v = x1;
         return set((scalar_t)(c0.t[0] * c1.t[0]), (scalar_t)(c0.t[1] * c1.t[1]));
-#endif // __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#endif //  __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS and __FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS
     }
 
     static INLINE CONST vect_t mul(const vect_t a, const vect_t b) { return mullo(a, b); }

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -686,13 +686,13 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
 		// return Simd256_64::vor(C,A1);
 		vect_t C,A1,B1;
 			//C  = Simd256_64::mulx(a,b);
-		C  = _mm256_mul_epi32(a,b);
+		C  = _mm256_mul_epu32(a,b);
 			//A1 = Simd256_64::srl(a,32);
 		A1 = _mm256_srli_epi64(a, 32);
 			//B1 = Simd256_64::srl(b,32);
 		B1 = _mm256_srli_epi64(b, 32);
 			//A1 = Simd256_64::mulx(A1,B1);
-		A1 =  _mm256_mul_epi32(A1,B1);
+		A1 =  _mm256_mul_epu32(A1,B1);
 			//C  = Simd256_64::srl(C,32);
 		C  = _mm256_srli_epi64(C, 32);
 			//A1 = Simd256_64::srl(A1,32);

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -684,13 +684,13 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
         // return Simd256_64::vor(C,A1);
         vect_t C,A1,B1;
         //C  = Simd256_64::mulx(a,b);
-        C  = _mm256_mul_epi32(a,b);
+        C  = _mm256_mul_epu32(a,b);
         //A1 = Simd256_64::srl(a,32);
         A1 = _mm256_srli_epi64(a, 32);
         //B1 = Simd256_64::srl(b,32);
         B1 = _mm256_srli_epi64(b, 32);
         //A1 = Simd256_64::mulx(A1,B1);
-        A1 =  _mm256_mul_epi32(A1,B1);
+        A1 =  _mm256_mul_epu32(A1,B1);
         //C  = Simd256_64::srl(C,32);
         C  = _mm256_srli_epi64(C, 32);
         //A1 = Simd256_64::srl(A1,32);

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -188,7 +188,7 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
      */
     template <int s>
     static INLINE CONST vect_t sra(const vect_t a) {
-#ifdef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#if defined(__FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS) and defined(__FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS)
         return _mm256_srai_epi64(a, s);
 #else
         vect_t m = sll<63-s>(set1(1));
@@ -305,7 +305,7 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
      *	   where (a smod p) is the signed representant of a modulo p, that is -p/2 <= (a smod p) < p/2
      */
     static INLINE CONST vect_t mullo(vect_t a, vect_t b) {
-#ifdef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+#if  defined(__FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS) and defined(__FFLASFFPACK_HAVE_AVX512VL_INSTRUCTIONS)
         return _mm256_mullo_epi64(a, b);
 #else
         //#pragma warning "The simd mullo function is emulate, it may impact the performances."

--- a/macros/instr_set.m4
+++ b/macros/instr_set.m4
@@ -21,7 +21,8 @@ AC_DEFUN([INSTR_SET],
         AC_ARG_ENABLE(avx,[AC_HELP_STRING([--disable-avx], [ disable AVX instruction set (enabled by default when available)])],[],[])
         AC_ARG_ENABLE(avx2,[AC_HELP_STRING([--disable-avx2], [ disable AVX2 instruction set (enabled by default when available)])],[],[])
         AC_ARG_ENABLE(avx512f, [AC_HELP_STRING([--disable-avx512f], [ disable AVX512F instruction set (enabled by default when available)])],[],[])
-        AC_ARG_ENABLE(avx512dq, [AC_HELP_STRING([--disable-avx512dq], [ disable AVX512DQ instruction set (enabled by default when available)])],[],[])        
+        AC_ARG_ENABLE(avx512dq, [AC_HELP_STRING([--disable-avx512dq], [ disable AVX512DQ instruction set (enabled by default when available)])],[],[])
+        AC_ARG_ENABLE(avx512vl, [AC_HELP_STRING([--disable-avx512vl], [ disable AVX512VL instruction set (enabled by default when available)])],[],[])
         AC_ARG_ENABLE(fma,[AC_HELP_STRING([--disable-fma], [ disable FMA instruction set (enabled by default when available)])],[],[])
         AC_ARG_ENABLE(fma4,[AC_HELP_STRING([--disable-fma4], [ disable FMA4 instruction set (enabled by default when available)])],[],[])
 
@@ -70,6 +71,10 @@ AC_DEFUN([INSTR_SET],
                         AS_ECHO("AVX512F enabled")
                         SIMD_CFLAGS="${SIMD_CFLAGS} -mavx512f"
                 ],[AS_ECHO("AVX512F disabled")])
+                AS_IF([ test "$iset" -ge "11" -a "x$enable_avx512vl" != "xno" ], [
+                        AS_ECHO("AVX512VL enabled")
+                        SIMD_CFLAGS="${SIMD_CFLAGS} -mavx512vl"
+                ],[AS_ECHO("AVX512VL disabled")])
                 AS_IF([ test "$iset" -ge "12" -a "x$enable_avx512dq" != "xno" ], [
                         AS_ECHO("AVX512DQ enabled")
                         SIMD_CFLAGS="${SIMD_CFLAGS} -mavx512dq"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ BASIC_TESTS =               \
 		test-io      \
 		test-maxdelayeddim \
 		test-solve \
+		test-simd \
 		test-fgemv \
 		test-nullspace \
 		regression-check
@@ -159,6 +160,7 @@ test_maxdelayeddim_SOURCES = test-maxdelayeddim.C
 regression_check_SOURCES = regression-check.C
 
 test_solve_SOURCES = test-solve.C
+test_simd_SOURCES = test-simd.C
 test_fgemv_SOURCES = test-fgemv.C
 #test_pfgemm_DSL_SOURCES = test-pfgemm-DSL.C
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -432,11 +432,17 @@ main (int argc, char *argv[]) {
     bool pass  = true ;
     pass &= test<float>();
     pass &= test<double>();
+#ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+        // Not yet implemented over AVX512
     pass &= test<int16_t>();
     pass &= test<int32_t>();
+#endif
     pass &= test<int64_t>();
+#ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
+        // Not yet implemented over AVX512
     pass &= test<uint16_t>();
     pass &= test<uint32_t>();
+#endif
     pass &= test<uint64_t>();
 
     cout << endl << "Test " << (pass ? "passed" : "failed") << endl;

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -388,7 +388,30 @@ test_impl () {
 /* Test all SIMD implems for one Element type *********************************/
 /******************************************************************************/
 template<class Element>
-bool
+typename enable_if<is_integral<Element>::value, bool>::type
+test () {
+    bool test = true;
+
+#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+    test &= test_impl<Simd128<Element>, Element>();
+    cout << endl;
+#endif
+
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+    test &= test_impl<Simd256<Element>, Element>();
+    cout << endl;
+#endif
+
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
+    test &= test_impl<Simd512<Element>, Element>();
+    cout << endl;
+#endif
+
+    return test;
+}
+
+template<class Element>
+typename enable_if<is_floating_point<Element>::value, bool>::type
 test () {
     bool test = true;
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -32,6 +32,7 @@
 #include "fflas-ffpack/utils/test-utils.h" /* for FFLAS::getSeed */
 #include "fflas-ffpack/utils/align-allocator.h"
 
+#include <array>
 #include <vector>
 #include <random>
 #include <string>


### PR DESCRIPTION
I rewrote test-simd.C and added it in tests/Makefile.am in order to add it in the test suite

I had one question: for the tests of SIMD functions on float and double, we generate random vector of real between [-MAX, MAX] with a uniform distribution. So most of the elements are very large (like 1e307 for double). But in practice we use those functions with smaller values (less than 1e27 or 1e53). Should we try to generate smaller values to match our usage of those functions or we do not care ?

This is a WIP, there are some functions that are not tested yet.