### PR TITLE
test-simd.C: adding simd methods

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -242,14 +242,6 @@ template <> struct Simd128_impl<true, false, true, 8> {
 #endif
     }
 
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the negated intermediate result
-     * to packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1], [b0, b1], [c0, c1]
-     * Return : [-(a0*b0)+c0, -(a1*b1)+c1]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -265,14 +257,6 @@ template <> struct Simd128_impl<true, false, true, 8> {
         return sub(mul(a, b), c);
 #endif
     }
-
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1], [b0, b1], [c0, c1]
-     * Return : [a0*b0-c0, a1*b1-c1]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -251,14 +251,6 @@ template <> struct Simd128_impl<true, false, true, 4> {
 #endif
     }
 
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -274,14 +266,6 @@ template <> struct Simd128_impl<true, false, true, 4> {
         return sub(mul(a, b), c);
 #endif
     }
-
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [a0*b0-c0, a1*b1-c1, a2*b2-c2, a3*b3-c3]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -631,6 +631,8 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
 
     static INLINE CONST vect_t fmaddx(const vect_t c, const vect_t a, const vect_t b) { return add(c, mulx(a, b)); }
 
+    static INLINE vect_t fmaddxin(vect_t &c, const vect_t a, const vect_t b) { return c = fmaddx(c, a, b); }
+
     static INLINE CONST vect_t fnmaddx(const vect_t c, const vect_t a, const vect_t b) { return sub(c, mulx(a, b)); }
 
     static INLINE vect_t fnmaddxin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmaddx(c, a, b); }

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -234,22 +234,6 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
 #endif
     }
 
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3]
-     */
-    static INLINE CONST vect_t madd(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3]
-     */
-    static INLINE CONST vect_t maddx(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
     static INLINE CONST vect_t fmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fmadd(c, a, b); }
 
     /*
@@ -266,14 +250,6 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
 #endif
     }
 
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the negated intermediate result
-     * to packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [-(a0*b0)+c0, -(a1*b1)+c1, -(a2*b2)+c2, -(a3*b3)+c3]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -289,14 +265,6 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
         return sub(mul(a, b), c);
 #endif
     }
-
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3], [b0, b1, b2, b3], [c0, c1, c2, c3]
-     * Return : [a0*b0-c0, a1*b1-c1, a2*b2-c2, a3*b3-c3]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -230,22 +230,6 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
 #endif
     }
 
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7]
-     */
-    static INLINE CONST vect_t madd(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7]
-     */
-    static INLINE CONST vect_t maddx(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
     static INLINE CONST vect_t fmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fmadd(c, a, b); }
 
     /*
@@ -262,14 +246,6 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
 #endif
     }
 
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the negated intermediate result
-     * to packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [-(a0*b0)+c0, -(a1*b1)+c1, -(a2*b2)+c2, -(a3*b3)+c3, -(a4*b4)+c4, -(a5*b5)+c5, -(a6*b6)+c6, -(a7*b7)+c7]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -285,14 +261,6 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
         return sub(mul(a, b), c);
 #endif
     }
-
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0-c0, a1*b1-c1, a2*b2-c2, a3*b3-c3, a4*b4-c4, a5*b5-c5, a6*b6-c6, a7*b7-c7]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512.inl
@@ -55,12 +55,28 @@ struct Simd512i_base {
     static INLINE CONST vect_t vor(const vect_t a, const vect_t b) { return _mm512_or_si512(b, a); }
 
     /*
+     * Compute the bitwise XOR and store the results in vect_t.
+     * Args   : [a0, ..., a511]
+     *		   [b0, ..., b511]
+     * Return : [a0 XOR b0, ..., a511 XOR b511]
+     */
+    static INLINE CONST vect_t vxor(const vect_t a, const vect_t b) { return _mm512_xor_si512(b, a); }
+
+    /*
      * Compute the bitwise AND and store the results in vect_t.
      * Args   : [a0, ..., a255]
      *		   [b0, ..., b255]
      * Return : [a0 AND b0, ..., a255 AND b255]
      */
     static INLINE CONST vect_t vand(const vect_t a, const vect_t b) { return _mm512_and_si512(b, a); }
+
+    /*
+     * Compute the bitwise NOT AND and store the results in vect_t.
+     * Args   : [a0, ..., a511]
+     *		   [b0, ..., b511]
+     * Return : [(NOT a0) AND b0, ..., (NOT a511) AND b511]
+     */
+    static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm512_andnot_si512(a, b); }
 
 
 };

--- a/fflas-ffpack/fflas/fflas_simd/simd512.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512.inl
@@ -48,9 +48,9 @@ struct Simd512i_base {
 
     /*
      * Compute the bitwise OR and store the results in vect_t.
-     * Args   : [a0, ..., a255]
-     *		   [b0, ..., b255]
-     * Return : [a0 OR b0, ..., a255 OR b255]
+     * Args   : [a0, ..., a511]
+     *		   [b0, ..., b511]
+     * Return : [a0 OR b0, ..., a511 OR b511]
      */
     static INLINE CONST vect_t vor(const vect_t a, const vect_t b) { return _mm512_or_si512(b, a); }
 
@@ -64,9 +64,9 @@ struct Simd512i_base {
 
     /*
      * Compute the bitwise AND and store the results in vect_t.
-     * Args   : [a0, ..., a255]
-     *		   [b0, ..., b255]
-     * Return : [a0 AND b0, ..., a255 AND b255]
+     * Args   : [a0, ..., a511]
+     *		   [b0, ..., b511]
+     * Return : [a0 AND b0, ..., a511 AND b511]
      */
     static INLINE CONST vect_t vand(const vect_t a, const vect_t b) { return _mm512_and_si512(b, a); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -255,22 +255,6 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
         return _mm512_fmadd_pd(a, b, c);
     }
 
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7]
-     */
-    static INLINE CONST vect_t madd(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7]
-     */
-    static INLINE CONST vect_t maddx(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
     static INLINE CONST vect_t fmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fmadd(c, a, b); }
 
     /*
@@ -283,14 +267,6 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
         return _mm512_fnmadd_pd(a, b, c);
     }
 
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, add the negated intermediate result
-     * to packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [-(a0*b0)+c0, -(a1*b1)+c1, -(a2*b2)+c2, -(a3*b3)+c3, -(a4*b4)+c4, -(a5*b5)+c5, -(a6*b6)+c6, -(a7*b7)+c7]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -302,14 +278,6 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
     static INLINE CONST vect_t fmsub(const vect_t c, const vect_t a, const vect_t b) {
         return _mm512_fmsub_pd(a, b, c);
     }
-
-    /*
-     * Multiply packed double-precision (64-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7], [c0, c1, c2, c3, c4, c5, c6, c7]
-     * Return : [a0*b0-c0, a1*b1-c1, a2*b2-c2, a3*b3-c3, a4*b4-c4, a5*b5-c5, a6*b6-c6, a7*b7-c7]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -257,28 +257,6 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
         return _mm512_fmadd_ps(a, b, c);
     }
 
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15],
-     *			[b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15],
-     *			[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7,
-     *			a8*b8+c8, a9*b9+c9, a10*b10+c10, a11*b11+c11, a12*b12+c12, a13*b13+c13, a14*b14+c14, a15*b15+c15]
-     */
-    static INLINE CONST vect_t madd(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the intermediate result to
-     * packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15],
-     *			[b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15],
-     *			[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15]
-     * Return : [a0*b0+c0, a1*b1+c1, a2*b2+c2, a3*b3+c3, a4*b4+c4, a5*b5+c5, a6*b6+c6, a7*b7+c7,
-     *			a8*b8+c8, a9*b9+c9, a10*b10+c10, a11*b11+c11, a12*b12+c12, a13*b13+c13, a14*b14+c14, a15*b15+c15]
-     */
-    static INLINE CONST vect_t maddx(const vect_t c, const vect_t a, const vect_t b) { return fmadd(c, a, b); }
-
     static INLINE CONST vect_t fmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fmadd(c, a, b); }
 
     /*
@@ -294,17 +272,6 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
         return _mm512_fnmadd_ps(a, b, c);
     }
 
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, add the negated intermediate result
-     * to packed elements in c, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15],
-     *			[b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15],
-     *			[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15]
-     * Return : [-(a0*b0)+c0, -(a1*b1)+c1, -(a2*b2)+c2, -(a3*b3)+c3, -(a4*b4)+c4, -(a5*b5)+c5, -(a6*b6)+c6, -(a7*b7)+c7,
-     *			-(a8*b8)+c8, -(a9*b9)+c9, -(a10*b10)+c10, -(a11*b11)+c11, -(a12*b12)+c12, -(a13*b13)+c13, -(a14*b14)+c14, -(a15*b15)+c15]
-     */
-    static INLINE CONST vect_t nmadd(const vect_t c, const vect_t a, const vect_t b) { return fnmadd(c, a, b); }
-
     static INLINE CONST vect_t fnmaddin(vect_t &c, const vect_t a, const vect_t b) { return c = fnmadd(c, a, b); }
 
     /*
@@ -319,17 +286,6 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static INLINE CONST vect_t fmsub(const vect_t c, const vect_t a, const vect_t b) {
         return _mm512_fmsub_ps(a, b, c);
     }
-
-    /*
-     * Multiply packed single-precision (32-bit) floating-point elements in a and b, subtract packed elements in c from
-     * the intermediate result, and store the results in vect_t.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15],
-     *			[b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15],
-     *			[c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15]
-     * Return : [a0*b0-c0, a1*b1-c1, a2*b2-c2, a3*b3-c3, a4*b4-c4, a5*b5-c5, a6*b6-c6, a7*b7-c7,
-     *			a8*b8-c8, a9*b9-c9, a10*b10-c10, a11*b11-c11, a12*b12-c12, a13*b13-c13, a14*b14-c14, a15*b15-c15]
-     */
-    static INLINE CONST vect_t msub(const vect_t c, const vect_t a, const vect_t b) { return fmsub(c, a, b); }
 
     static INLINE CONST vect_t fmsubin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsub(c, a, b); }
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -46,6 +46,8 @@ using std::cout;
 using std::endl;
 using std::string;
 using std::vector;
+using std::array;
+using std::function;
 using std::numeric_limits;
 using std::enable_if;
 using std::is_floating_point;
@@ -115,19 +117,18 @@ check_eq (Element x, Element y)
 /* evaluate the function f with arguments taken in the array */
 template <class Ret, class T>
 Ret
-eval_func_on_array (std::function<Ret()> f, std::array<T, 0> arr)
+eval_func_on_array (function<Ret()> f, array<T, 0> arr)
 {
     return f();
 }
 
 template <class Ret, class T, class...TArgs>
 Ret
-eval_func_on_array (std::function<Ret(T, TArgs...)> f,
-                    std::array<T, sizeof...(TArgs)+1> arr)
+eval_func_on_array (function<Ret(T, TArgs...)> f,
+                    array<T, sizeof...(TArgs)+1> arr)
 {
-    std::function<Ret(TArgs...)> newf = [&] (TArgs...args) -> Ret { return
-        f(arr[0], args...);};
-    std::array<T, sizeof...(TArgs)> newarr;
+    function<Ret(TArgs...)> newf = [&] (TArgs...args) -> Ret { return f(arr[0], args...);};
+    array<T, sizeof...(TArgs)> newarr;
     for (size_t i = 0; i < sizeof...(TArgs); i++)
         newarr[i] = arr[i+1];
     return eval_func_on_array (newf, newarr);
@@ -159,8 +160,8 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     ScalVect out_scal(SimdVectSize), out_simd(SimdVectSize);
 
     /* compute with scalar function */
-    std::array<Element, arity> scal_in;
-    std::function<RScal(AScal...)> fscal = FScal;
+    array<Element, arity> scal_in;
+    function<RScal(AScal...)> fscal = FScal;
     for(size_t i = 0 ; i < SimdVectSize ; i++) {
         for (size_t j = 0; j < arity; j++)
             scal_in[j] = inputs[j][i];
@@ -169,8 +170,8 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     }
 
     /* compute with SIMD function */
-    std::array<SimdVect, arity> simd_in;
-    std::function<RSimd(ASimd...)> fsimd = FSimd;
+    array<SimdVect, arity> simd_in;
+    function<RSimd(ASimd...)> fsimd = FSimd;
     for (size_t i = 0; i < arity; i++)
         simd_in[i] = Simd::load (inputs[i].data());
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -83,14 +83,11 @@ generate_random_vector (vector<Element,Alloc> &a) {
     std::generate (a.begin(), a.end(), [&](){return G(entropy_generator);});
 }
 
-// FIXME float value are too large
 template <class Element, class Alloc>
 typename enable_if<is_floating_point<Element>::value>::type
 generate_random_vector (vector<Element,Alloc> &a) {
     typedef typename std::uniform_real_distribution<Element> RandGen;
     RandGen G(numeric_limits<Element>::lowest(),numeric_limits<Element>::max());
-    //typedef typename std::normal_distribution<Element> RandGen;
-    //RandGen G(0.0, Givaro::Modular<Element>::maxCardinality());
     std::generate (a.begin(), a.end(), [&](){return G(entropy_generator);});
 }
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -262,6 +262,9 @@ template <class Element>
 struct ScalFunctions<Element,
                     typename enable_if<is_integral<Element>::value>::type>
 {
+    static Element round (Element x) {
+        return x;
+    }
     static Element add (Element x1, Element x2) {
         return x1+x2;
     }
@@ -395,6 +398,7 @@ test_impl () {
     using Scal = ScalFunctions<Element>;
     bool btest = true;
 
+    TEST_ONE_OP (round);
     TEST_ONE_OP (add);
     TEST_ONE_OP (sub);
     TEST_ONE_OP (mul);

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -223,20 +223,38 @@ struct ScalFunctions<Element,
     static Element add (Element x1, Element x2) {
         return x1+x2;
     }
+    static Element addin (Element &x1, Element x2) {
+        return x1+=x2;
+    }
     static Element sub (Element x1, Element x2) {
         return x1-x2;
+    }
+    static Element subin (Element &x1, Element x2) {
+        return x1-=x2;
     }
     static Element mul (Element x1, Element x2) {
         return x1*x2;
     }
+    static Element mulin (Element &x1, Element x2) {
+        return x1*=x2;
+    }
     static Element fmadd (Element x1, Element x2, Element x3) {
         return std::fma(x3,x2,x1);
+    }
+    static Element fmaddin (Element &x1, Element x2, Element x3) {
+        return x1 = std::fma(x3,x2,x1);
     }
     static Element fmsub (Element x1, Element x2, Element x3) {
         return std::fma(x3,x2,-x1);
     }
+    static Element fmsubin (Element &x1, Element x2, Element x3) {
+        return x1 = std::fma(x3,x2,-x1);
+    }
     static Element fnmadd (Element x1, Element x2, Element x3) {
         return std::fma(-x3,x2,x1);
+    }
+    static Element fnmaddin (Element &x1, Element x2, Element x3) {
+        return x1 = std::fma(-x3,x2,x1);
     }
     /* Comparisons functions in SIMD output 0 or 0xFFFF...FFFF
      * (here we assume 0xFFFF...FFFF is always a NAN)
@@ -411,11 +429,17 @@ test_impl () {
     TEST_ONE_OP (floor);
     TEST_ONE_OP (round);
     TEST_ONE_OP (add);
+    TEST_ONE_OP (addin);
     TEST_ONE_OP (sub);
+    TEST_ONE_OP (subin);
     TEST_ONE_OP (mul);
+    TEST_ONE_OP (mulin);
     TEST_ONE_OP (fmadd);
+    TEST_ONE_OP (fmaddin);
     TEST_ONE_OP (fmsub);
+    TEST_ONE_OP (fmsubin);
     TEST_ONE_OP (fnmadd);
+    TEST_ONE_OP (fnmaddin);
     TEST_ONE_OP (lesser);
     TEST_ONE_OP (lesser_eq);
     TEST_ONE_OP (greater);

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -303,13 +303,22 @@ struct ScalFunctions<Element,
         return x1*x2;
     }
     static Element fmadd (Element x1, Element x2, Element x3) {
-        return x1+x3*x2;
+        return x1 + x2*x3;
+    }
+    static Element fmaddx (Element x1, Element x2, Element x3) {
+        return x1 + mulx (x2, x3);
     }
     static Element fmsub (Element x1, Element x2, Element x3) {
-        return -x1 + x3*x2;
+        return -x1 + x2*x3;
+    }
+    static Element fmsubx (Element x1, Element x2, Element x3) {
+        return -x1 + mulx (x2, x3);
     }
     static Element fnmadd (Element x1, Element x2, Element x3) {
-        return x1 - x3*x2;
+        return x1 - x2*x3;
+    }
+    static Element fnmaddx (Element x1, Element x2, Element x3) {
+        return x1 - mulx(x2, x3);
     }
 
     /* Shift */
@@ -406,8 +415,11 @@ test_impl () {
     TEST_ONE_OP (mulhi);
     TEST_ONE_OP (mulx);
     TEST_ONE_OP (fmadd);
+    TEST_ONE_OP (fmaddx);
     TEST_ONE_OP (fmsub);
+    TEST_ONE_OP (fmsubx);
     TEST_ONE_OP (fnmadd);
+    TEST_ONE_OP (fnmaddx);
     TEST_ONE_OP (lesser);
     TEST_ONE_OP (lesser_eq);
     TEST_ONE_OP (greater);

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -90,7 +90,7 @@ template <class Element, class Alloc>
 typename enable_if<is_floating_point<Element>::value>::type
 generate_random_vector (vector<Element,Alloc> &a) {
     typedef typename std::uniform_real_distribution<Element> RandGen;
-    RandGen G(numeric_limits<Element>::lowest(),numeric_limits<Element>::max());
+    RandGen G(numeric_limits<Element>::min(),numeric_limits<Element>::max());
     std::generate (a.begin(), a.end(), [&](){return G(entropy_generator);});
 }
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -544,12 +544,17 @@ test_impl () {
     TEST_ONE_OP (greater);
     TEST_ONE_OP (greater_eq);
     TEST_ONE_OP (eq);
+#if ! defined (__GNUC__) || __GNUC__ >= 6
+    /* TODO: these tests are disabled with gcc < 6, I do not know how to compile
+     * the following lines with gcc 4.9 and gcc 5.x
+     */
     TEST_ONE_OP (template sra<3>);
     TEST_ONE_OP (template sra<7>);
     TEST_ONE_OP (template srl<5>);
     TEST_ONE_OP (template srl<11>);
     TEST_ONE_OP (template sll<2>);
     TEST_ONE_OP (template sll<13>);
+#endif
 
     return btest;
 }

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -467,7 +467,7 @@ struct ScalFunctions<Element,
 /******************************************************************************/
 
 #define TEST_ONE_OP(name) \
-    btest &= test_op<simd,Element> (simd::name, Scal::name, #name);
+    btest &= test_op<simd> (simd::name, Scal::name, #name);
 
 /* for floating point element */
 template<class simd, class Element>
@@ -544,17 +544,12 @@ test_impl () {
     TEST_ONE_OP (greater);
     TEST_ONE_OP (greater_eq);
     TEST_ONE_OP (eq);
-#if ! defined (__GNUC__) || __GNUC__ >= 6
-    /* TODO: these tests are disabled with gcc < 6, I do not know how to compile
-     * the following lines with gcc 4.9 and gcc 5.x
-     */
     TEST_ONE_OP (template sra<3>);
     TEST_ONE_OP (template sra<7>);
     TEST_ONE_OP (template srl<5>);
     TEST_ONE_OP (template srl<11>);
     TEST_ONE_OP (template sll<2>);
     TEST_ONE_OP (template sll<13>);
-#endif
 
     return btest;
 }


### PR DESCRIPTION
- Added tests for lots of methods in `test-simd.C`
- Fix #219 (I hope)
- adding missing method in somes cases: f4b57ba and 7aa5706
- removing madd, msub, nmadd: they were just aliases to fmadd, fmsub and fnmadd and they were never used in fflas nor Linbox (fbc3db6)
 
They are still methods in SIMD files that need to be tested, in particular all the methods that perform shuffle, unpacking, permutation, ...
But if the tests pass, this PR could be merged, I will try to add these tests in another branch.

Edit: according to Travis, there is a problem on this branch with GCC 4.9 and GCC 5, I will look into it.