### PR TITLE
Add a type_name static member to SIMD struct

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -319,7 +319,7 @@ struct NoSimd {
     static const constexpr size_t vect_size = 1;
 
     /* Name of the NoSimd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "NoSimd"; }
 
     // Test if the pointer p is multiple of alignment
     template <class TT> static constexpr bool valid(TT p) { return false; }
@@ -327,9 +327,6 @@ struct NoSimd {
     // Test if n is multiple of vect_size
     template <class TT> static constexpr bool compliant(TT n) { return false; }
 };
-
-template<typename T>
-const char NoSimd<T>::type_name[] = "NoSimd";
 
 // #if defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 

--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -318,12 +318,18 @@ struct NoSimd {
      */
     static const constexpr size_t vect_size = 1;
 
+    /* Name of the NoSimd struct */
+    static const char type_name[];
+
     // Test if the pointer p is multiple of alignment
     template <class TT> static constexpr bool valid(TT p) { return false; }
 
     // Test if n is multiple of vect_size
     template <class TT> static constexpr bool compliant(TT n) { return false; }
 };
+
+template<typename T>
+const char NoSimd<T>::type_name[] = "NoSimd";
 
 // #if defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128.inl
@@ -31,11 +31,10 @@
 struct Simd128fp_base {
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd128"; }
 
 
 };
-const char Simd128fp_base::type_name[] = "Simd128";
 
 struct Simd128i_base {
 
@@ -45,7 +44,7 @@ struct Simd128i_base {
     using vect_t = __m128i;
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd128"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -102,7 +101,6 @@ struct Simd128i_base {
     static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm_andnot_si128(a, b); }
 
 };
-const char Simd128i_base::type_name[] = "Simd128";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd128_impl;
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128.inl
@@ -28,12 +28,24 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_INL
 
+struct Simd128fp_base {
+
+    /* Name of the Simd struct */
+    static const char type_name[];
+
+
+};
+const char Simd128fp_base::type_name[] = "Simd128";
+
 struct Simd128i_base {
 
     /*
      * alias to 128 bit simd register
      */
     using vect_t = __m128i;
+
+    /* Name of the Simd struct */
+    static const char type_name[];
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -90,6 +102,7 @@ struct Simd128i_base {
     static INLINE CONST vect_t vandnot(const vect_t a, const vect_t b) { return _mm_andnot_si128(a, b); }
 
 };
+const char Simd128i_base::type_name[] = "Simd128";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd128_impl;
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -31,7 +31,7 @@
 /*
  * Simd128 specialized for double
  */
-template <> struct Simd128_impl<true, false, true, 8> {
+template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
 #if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -31,7 +31,7 @@
 /*
  * Simd128 specialized for float
  */
-template <> struct Simd128_impl<true, false, true, 4> {
+template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
 #if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -31,6 +31,9 @@
 struct Simd256fp_base {
 #if defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 
+    /* Name of the Simd struct */
+    static const char type_name[];
+
     /*
      * Shuffle 128-bits selected by imm8 from a and b, and store the results in dst.
      * Args   :	[a0, a1]
@@ -67,6 +70,7 @@ struct Simd256fp_base {
 
 #endif
 };
+const char Simd256fp_base::type_name[] = "Simd256";
 
 struct Simd256i_base {
 
@@ -74,6 +78,9 @@ struct Simd256i_base {
      * alias to 256 bit simd register
      */
     using vect_t = __m256i;
+
+    /* Name of the Simd struct */
+    static const char type_name[];
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -167,6 +174,7 @@ struct Simd256i_base {
     static INLINE CONST vect_t unpackhi128(const vect_t a, const vect_t b) { return permute128<0x31>(a, b); }
 #endif
 };
+const char Simd256i_base::type_name[] = "Simd256";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd256_impl;
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -32,7 +32,7 @@ struct Simd256fp_base {
 #if defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd256"; }
 
     /*
      * Shuffle 128-bits selected by imm8 from a and b, and store the results in dst.
@@ -70,7 +70,6 @@ struct Simd256fp_base {
 
 #endif
 };
-const char Simd256fp_base::type_name[] = "Simd256";
 
 struct Simd256i_base {
 
@@ -80,7 +79,7 @@ struct Simd256i_base {
     using vect_t = __m256i;
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd256"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -174,7 +173,6 @@ struct Simd256i_base {
     static INLINE CONST vect_t unpackhi128(const vect_t a, const vect_t b) { return permute128<0x31>(a, b); }
 #endif
 };
-const char Simd256i_base::type_name[] = "Simd256";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd256_impl;
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512.inl
@@ -31,11 +31,10 @@
 struct Simd512fp_base {
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd512"; }
 
 
 };
-const char Simd512fp_base::type_name[] = "Simd512";
 
 struct Simd512i_base {
 
@@ -45,7 +44,7 @@ struct Simd512i_base {
     using vect_t = __m512i;
 
     /* Name of the Simd struct */
-    static const char type_name[];
+    static inline const std::string type_string () { return "Simd512"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -71,7 +70,6 @@ struct Simd512i_base {
 
 
 };
-const char Simd512i_base::type_name[] = "Simd512";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd512_impl;
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512.inl
@@ -30,8 +30,12 @@
 
 struct Simd512fp_base {
 
+    /* Name of the Simd struct */
+    static const char type_name[];
+
 
 };
+const char Simd512fp_base::type_name[] = "Simd512";
 
 struct Simd512i_base {
 
@@ -39,6 +43,9 @@ struct Simd512i_base {
      * alias to 512 bit simd register
      */
     using vect_t = __m512i;
+
+    /* Name of the Simd struct */
+    static const char type_name[];
 
     /*
      *  Return vector of type vect_t with all elements set to zero
@@ -64,6 +71,7 @@ struct Simd512i_base {
 
 
 };
+const char Simd512i_base::type_name[] = "Simd512";
 
 template <bool ArithType, bool Int, bool Signed, int Size> struct Simd512_impl;
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -181,7 +181,7 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
 
     /* print result line */
-    cout << Simd::type_name << "<" << TypeName<Element>() << ">::" << fname
+    cout << Simd::type_string() << "<" << TypeName<Element>() << ">::" << fname
          << " " << string (60 - fname.size() - strlen(TypeName<Element>()), '.')
          << " " << (res ? "success" : "failure") << endl;
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -147,7 +147,6 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     using ScalVect = vector<Element, ScalVectAlign>;
     using SimdVect = typename Simd::vect_t;
     constexpr size_t SimdVectSize = Simd::vect_size;
-    constexpr size_t simd_size = sizeof(Element) * SimdVectSize * 8;
     constexpr size_t arity = sizeof...(AScal);
 
     /* input vectors */
@@ -182,7 +181,7 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
 
     /* print result line */
-    cout << "Simd" << simd_size << "<" << TypeName<Element>() << ">::" << fname
+    cout << Simd::type_name << "<" << TypeName<Element>() << ">::" << fname
          << " " << string (60 - fname.size() - strlen(TypeName<Element>()), '.')
          << " " << (res ? "success" : "failure") << endl;
 


### PR DESCRIPTION
The main goal is to ease the pretty printing of SIMD type in tests and benchs.
Useful for example in the tests and benchs written in the `FFT_modular_double` branch of Linbox.