### PR TITLE
Fixed --with-blas options giving 'ld cannot find xxx.so' at configure time

### DIFF
--- a/macros/fflas-ffpack-blas.m4
+++ b/macros/fflas-ffpack-blas.m4
@@ -51,7 +51,7 @@ AC_DEFUN([FF_CHECK_USER_BLAS],
 		BACKUP_CXXFLAGS=${CXXFLAGS}
 		BACKUP_LIBS=${LIBS}
 		saved_LD_RUN_PATH="$LD_RUN_PATH"
-		blas_lib_path=`echo $CBLAS_LIBS | $EGREP '\-L' | $SED -e 's/-L//;s/ .*//'`
+		blas_lib_path=`echo $BLAS_LIBS | $EGREP '\-L' | $SED -e 's/-L//;s/ .*//'`
 		LD_RUN_PATH="${LD_RUN_PATH:+$LD_RUN_PATH$PATH_SEPARATOR}$blas_lib_path"
 		export LD_RUN_PATH
 		CODE_CBLAS=`cat ${srcdir}/macros/CodeChunk/cblas.C`


### PR DESCRIPTION
Somehow I wasn't able to configure fflas-ffpack with valid options : `./autogen.sh --with-blas-libs="-L/home/breust/dev/build/lib/ -lblis" --with-blas-cflags="-I/home/breust/dev/build/include/blis"`.

Getting an error "blas not found" and log:
```log
./conftest: error while loading shared libraries: libblis.so.2: cannot open shared object file: No such file or directory
```

It is somewhat linked to the `fflas-ffpack-blas.m4` macro:
```m4
saved_LD_RUN_PATH="$LD_RUN_PATH"
blas_lib_path=`echo $CBLAS_LIBS | $EGREP '\-L' | $SED -e 's/-L//;s/ .*//'`
LD_RUN_PATH="${LD_RUN_PATH:+$LD_RUN_PATH$PATH_SEPARATOR}$blas_lib_path"
export LD_RUN_PATH
```

Fact is `CBLAS_LIBS` is empty in my configuration, so LD_RUN_PATH too. Should it not be the case?

I changed it to `BLAS_LIBS`, and it looks like some Makefile.am files need this change too.