### PR TITLE
Ludivine to pluq

### DIFF
--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -297,8 +297,8 @@ namespace FFPACK { /* Permutations */
 namespace FFPACK { /* fgetrs, fgesv */
 
     /** Solve the system \f$A X = B\f$ or \f$X A = B\f$.
-     * Solving using the \c LQUP decomposition of \p A
-     * already computed inplace with \c LUdivine(FFLAS::FflasNoTrans, FFLAS::FflasNonUnit).
+     * Solving using the \c PLUQ decomposition of \p A
+     * already computed inplace with \c PLUQ (FFLAS::FflasNonUnit).
      * Version for A square.
      * If A is rank deficient, a solution is returned if the system is consistent,
      * Otherwise an info is 1
@@ -310,8 +310,8 @@ namespace FFPACK { /* fgetrs, fgesv */
      * @param R rank of \p A
      * @param A input matrix
      * @param lda leading dimension of \p A
-     * @param P column permutation of the \c LQUP decomposition of \p A
-     * @param Q column permutation of the \c LQUP decomposition of \p A
+     * @param P row permutation of the \c PLUQ decomposition of \p A
+     * @param Q column permutation of the \c PLUQ decomposition of \p A
      * @param B Right/Left hand side matrix. Initially stores \p B, finally stores the solution \p X.
      * @param ldb leading dimension of \p B
      * @param info Success of the computation: 0 if successfull, >0 if system is inconsistent
@@ -327,8 +327,8 @@ namespace FFPACK { /* fgetrs, fgesv */
             int * info);
 
     /** Solve the system A X = B or X A = B.
-     * Solving using the LQUP decomposition of A
-     * already computed inplace with LUdivine(FFLAS::FflasNoTrans, FFLAS::FflasNonUnit).
+     * Solving using the PLUQ decomposition of A
+     * already computed inplace with PLUQ(FFLAS::FflasNonUnit).
      * Version for A rectangular.
      * If A is rank deficient, a solution is returned if the system is consistent,
      * Otherwise an info is 1
@@ -341,8 +341,8 @@ namespace FFPACK { /* fgetrs, fgesv */
      * @param R rank of A
      * @param A input matrix
      * @param lda leading dimension of A
-     * @param P column permutation of the LQUP decomposition of A
-     * @param Q column permutation of the LQUP decomposition of A
+     * @param P row permutation of the PLUQ decomposition of A
+     * @param Q column permutation of the PLUQ decomposition of A
      * @param X solution matrix
      * @param ldx leading dimension of X
      * @param B Right/Left hand side matrix.
@@ -415,28 +415,11 @@ namespace FFPACK { /* fgetrs, fgesv */
            typename Field::Element_ptr X, const size_t ldx,
            typename Field::ConstElement_ptr B, const size_t ldb,
            int * info);
-
-    /**  Solve the system Ax=b.
-     * Solving using LQUP factorization and
-     * two triangular system resolutions.
-     * The input matrix is modified.
-     * @param F The computation domain
-     * @param M row dimension of the matrix
-     * @param A input matrix
-     * @param lda leading dimension of A
-     * @param x solution vector
-     * @param incx increment of x
-     * @param b right hand side vector
-     * @param incb increment of b
-     */
-
 } // FFPACK fgesv, fgetrs
 // #include "ffpack_fgesv.inl"
 // #include "ffpack_fgetrs.inl"
 
 namespace FFPACK { /* ftrtr */
-
-
 
     /** Compute the inverse of a triangular matrix.
      * @param F base field
@@ -1132,7 +1115,7 @@ namespace FFPACK { /* Solutions */
 
 
 
-    /** Computes the rank of the given matrix using a LQUP factorization.
+    /** Computes the rank of the given matrix using a PLUQ factorization.
      * The input matrix is modified.
      * @param F base field
      * @param M row dimension of the matrix
@@ -1171,7 +1154,7 @@ namespace FFPACK { /* Solutions */
 
     /** @brief Returns the determinant of the given matrix.
      * @details The method is a block elimination with early termination
-     * using LQUP factorization  with early termination. The input matrix A is overwritten.
+     * using PLUQ factorization  with early termination. The input matrix A is overwritten.
      * If <code>M != N</code>,
      * then the matrix is virtually padded with zeros to make it square and
      * it's determinant is zero.
@@ -1194,7 +1177,7 @@ namespace FFPACK { /* Solutions */
 
     /** @brief Returns the determinant of the given matrix.
      * @details The method is a block elimination with early termination
-     * using LQUP factorization  with early termination. The input matrix A is overwritten.
+     * using PLUQ factorization  with early termination. The input matrix A is overwritten.
      * If <code>M != N</code>,
      * then the matrix is virtually padded with zeros to make it square and
      * it's determinant is zero.
@@ -1221,7 +1204,7 @@ namespace FFPACK { /* Solutions */
 
 
     /**
-     * @brief Solves a linear system AX = b using LQUP factorization.
+     * @brief Solves a linear system AX = b using PLUQ factorization.
      * @oaram F base field
      * @oaram M matrix order
      * @param [in] A input matrix

--- a/fflas-ffpack/ffpack/ffpack.inl
+++ b/fflas-ffpack/ffpack/ffpack.inl
@@ -39,9 +39,9 @@ namespace FFPACK {
         if (M == 0 and  N  == 0)
             return 0 ;
 
-        size_t *P = FFLAS::fflas_new<size_t>(N);
-        size_t *Q = FFLAS::fflas_new<size_t>(M);
-        size_t R = LUdivine (F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, M, N, A, lda, P, Q);
+        size_t *P = FFLAS::fflas_new<size_t>(M);
+        size_t *Q = FFLAS::fflas_new<size_t>(N);
+        size_t R = PLUQ (F, FFLAS::FflasNonUnit, M, N, A, lda, P, Q);
         FFLAS::fflas_delete( Q);
         FFLAS::fflas_delete( P);
         return R;
@@ -106,7 +106,7 @@ namespace FFPACK {
 
     template <class Field>
     typename Field::Element
-    Det( const Field& F, const size_t M, const size_t N,
+    Det (const Field& F, const size_t M, const size_t N,
          typename Field::Element_ptr A, const size_t lda)
     {
         size_t *P = FFLAS::fflas_new<size_t>(N);
@@ -121,30 +121,27 @@ namespace FFPACK {
 
     template <class Field>
     typename Field::Element_ptr
-    Solve( const Field& F, const size_t M,
+    Solve (const Field& F, const size_t M,
            typename Field::Element_ptr A, const size_t lda,
            typename Field::Element_ptr x, const int incx,
-           typename Field::ConstElement_ptr b, const int incb )
+           typename Field::ConstElement_ptr b, const int incb)
     {
 
         size_t *P = FFLAS::fflas_new<size_t>(M);
         size_t *rowP = FFLAS::fflas_new<size_t>(M);
 
-        if (LUdivine( F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, M, M, A, lda, P, rowP) < M){
+        if (PLUQ (F, FFLAS::FflasNonUnit, M, M, A, lda, P, rowP) < M){
             std::cerr<<"SINGULAR MATRIX"<<std::endl;
-            FFLAS::fflas_delete( P);
-            FFLAS::fflas_delete( rowP);
+            FFLAS::fflas_delete (P);
+            FFLAS::fflas_delete (rowP);
             return x;
         }
         else{
             FFLAS::fassign( F, M, b, incb, x, incx );
 
-            ftrsv(F,  FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit, M,
-                  A, lda , x, incx);
-            ftrsv(F,  FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, M,
-                  A, lda , x, incx);
-            applyP( F, FFLAS::FflasLeft, FFLAS::FflasTrans,
-                    1, 0,(int) M, x, incx, P );
+            ftrsv (F, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit, M, A, lda , x, incx);
+            ftrsv (F, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, M, A, lda , x, incx);
+            applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans, 1, 0,(int) M, x, incx, P );
             FFLAS::fflas_delete( rowP);
             FFLAS::fflas_delete( P);
 
@@ -161,16 +158,16 @@ namespace FFPACK {
     {
         // Right kernel vector: X s.t. AX == 0
         if (Side == FFLAS::FflasRight) {
-            size_t* P = FFLAS::fflas_new<size_t>(N);
-            size_t* Qt = FFLAS::fflas_new<size_t>(M);
+            size_t* P = FFLAS::fflas_new<size_t>(M);
+            size_t* Q = FFLAS::fflas_new<size_t>(N);
 
-            size_t R = LUdivine(F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, M, N, A, lda, P, Qt);
-            FFLAS::fflas_delete(Qt);
+            size_t R = PLUQ (F, FFLAS::FflasNonUnit, M, N, A, lda, P, Q);
+            FFLAS::fflas_delete(P);
 
             // Nullspace is {0}
             if (N == R) {
                 FFLAS::fzero(F, N, X, incX);
-                FFLAS::fflas_delete(P);
+                FFLAS::fflas_delete(Q);
                 return;
             }
 
@@ -183,7 +180,7 @@ namespace FFPACK {
 
             // Nullspace is total, any random vector would do
             if (R == 0) {
-                FFLAS::fflas_delete(P);
+                FFLAS::fflas_delete(Q);
                 return;
             }
 
@@ -195,18 +192,18 @@ namespace FFPACK {
             FFLAS::ftrsv(F, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, R,
                          A, lda, X, (int)incX);
 
-            applyP(F, FFLAS::FflasLeft, FFLAS::FflasTrans, 1u, 0u, (int) R, X, 1u, P);
+            applyP(F, FFLAS::FflasLeft, FFLAS::FflasTrans, 1u, 0u, (int) N, X, 1u, Q);
 
-            FFLAS::fflas_delete(P);
+            FFLAS::fflas_delete(Q);
         }
 
         // Left kernel vector
         else {
             size_t* P = FFLAS::fflas_new<size_t>(M);
-            size_t* Qt = FFLAS::fflas_new<size_t>(N);
+            size_t* Q = FFLAS::fflas_new<size_t>(N);
 
-            size_t R = LUdivine(F, FFLAS::FflasNonUnit, FFLAS::FflasTrans, M, N, A, lda, P, Qt);
-            FFLAS::fflas_delete(Qt);
+            size_t R = PLUQ (F, FFLAS::FflasNonUnit, M, N, A, lda, P, Q);
+            FFLAS::fflas_delete(Q);
 
             // Nullspace is {0}
             if (M == R) {
@@ -233,10 +230,10 @@ namespace FFPACK {
                          F.mOne, A + R * lda, lda, X + R * incX, incX, 0u, X, incX);
 
             // Now get t1 such that t1 * L1 == -t2 * L2
-            FFLAS::ftrsv(F, FFLAS::FflasLower, FFLAS::FflasTrans, FFLAS::FflasNonUnit, R,
+            FFLAS::ftrsv(F, FFLAS::FflasLower, FFLAS::FflasTrans, FFLAS::FflasUnit, R,
                          A, lda, X, (int)incX);
 
-            applyP(F, FFLAS::FflasRight, FFLAS::FflasNoTrans, 1u, 0u, (int) R, X, 1u, P);
+            applyP(F, FFLAS::FflasRight, FFLAS::FflasNoTrans, 1u, 0u, (int) M, X, 1u, P);
 
             FFLAS::fflas_delete(P);
         }
@@ -249,18 +246,19 @@ namespace FFPACK {
                            typename Field::Element_ptr& NS, size_t& ldn,
                            size_t& NSdim)
     {
-        if (Side == FFLAS::FflasRight) { // Right NullSpace
-            size_t* P = FFLAS::fflas_new<size_t>(N);
-            size_t* Qt = FFLAS::fflas_new<size_t>(M);
+        size_t* P = FFLAS::fflas_new<size_t>(M);
+        size_t* Q = FFLAS::fflas_new<size_t>(N);
+        
+        size_t R = PLUQ (F, FFLAS::FflasNonUnit, M, N, A, lda, P, Q);
 
-            size_t R = LUdivine (F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, M, N, A, lda, P, Qt);
-            FFLAS::fflas_delete(Qt);
+        if (Side == FFLAS::FflasRight) { // Right NullSpace
+            FFLAS::fflas_delete(P);
 
             ldn = N-R;
             NSdim = ldn;
 
             if (NSdim == 0) {
-                FFLAS::fflas_delete( P);
+                FFLAS::fflas_delete (Q);
                 NS = NULL ;
                 return NSdim ;
             }
@@ -268,37 +266,32 @@ namespace FFPACK {
             NS = FFLAS::fflas_new (F, N, ldn);
 
             if (R == 0) {
-                FFLAS::fflas_delete( P);
+                FFLAS::fflas_delete(Q);
                 FFLAS::fidentity(F,N,ldn,NS,ldn);
                 return NSdim;
             }
 
-            FFLAS::fassign (F, R, ldn,  A + R,  lda, NS , ldn );
+            FFLAS::fassign (F, R, ldn,  A + R,  lda, NS , ldn);
 
             ftrsm (F, FFLAS::FflasLeft, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, R, ldn,
                    F.mOne, A, lda, NS, ldn);
 
             FFLAS::fidentity(F,NSdim,NSdim,NS+R*ldn,ldn);
 
-            applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans,
-                    NSdim, 0,(int) R, NS, ldn, P);
+            applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans, NSdim, 0,(int) N, NS, ldn, Q);
 
-            FFLAS::fflas_delete(P);
+            FFLAS::fflas_delete(Q);
 
             return NSdim;
         }
         else { // Left NullSpace
-            size_t* P = FFLAS::fflas_new<size_t>(M);
-            size_t* Qt = FFLAS::fflas_new<size_t>(N);
-
-            size_t R = LUdivine (F, FFLAS::FflasNonUnit, FFLAS::FflasTrans, M, N, A, lda, P, Qt);
-            FFLAS::fflas_delete(Qt);
+            FFLAS::fflas_delete(Q);
 
             ldn = M;
             NSdim = M-R;
 
             if (NSdim == 0) {
-                FFLAS::fflas_delete( P);
+                FFLAS::fflas_delete (P);
                 NS = NULL;
                 return NSdim;
             }
@@ -312,10 +305,10 @@ namespace FFPACK {
             }
 
             FFLAS::fassign (F, NSdim, R, A + R *lda, lda, NS, ldn);
-            ftrsm (F, FFLAS::FflasRight, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, NSdim, R, F.mOne, A, lda, NS, ldn);
+            ftrsm (F, FFLAS::FflasRight, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit, NSdim, R, F.mOne, A, lda, NS, ldn);
 
             FFLAS::fidentity(F,NSdim,NSdim,NS+R,ldn);
-            applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, NSdim, 0,(int) R, NS, ldn, P);
+            applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, NSdim, 0,(int) M, NS, ldn, P);
 
             FFLAS::fflas_delete(P);
             return NSdim;

--- a/fflas-ffpack/ffpack/ffpack.inl
+++ b/fflas-ffpack/ffpack/ffpack.inl
@@ -130,7 +130,7 @@ namespace FFPACK {
         size_t *P = FFLAS::fflas_new<size_t>(M);
         size_t *rowP = FFLAS::fflas_new<size_t>(M);
 
-        if (PLUQ (F, FFLAS::FflasNonUnit, M, M, A, lda, P, rowP) < M){
+        if (PLUQ (F, FFLAS::FflasNonUnit, M, M, A, lda, rowP, P) < M){
             std::cerr<<"SINGULAR MATRIX"<<std::endl;
             FFLAS::fflas_delete (P);
             FFLAS::fflas_delete (rowP);
@@ -139,6 +139,7 @@ namespace FFPACK {
         else{
             FFLAS::fassign( F, M, b, incb, x, incx );
 
+            applyP (F, FFLAS::FflasLeft, FFLAS::FflasNoTrans, 1, 0,(int) M, x, incx, rowP );
             ftrsv (F, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit, M, A, lda , x, incx);
             ftrsv (F, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit, M, A, lda , x, incx);
             applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans, 1, 0,(int) M, x, incx, P );

--- a/fflas-ffpack/ffpack/ffpack_fgesv.inl
+++ b/fflas-ffpack/ffpack/ffpack_fgesv.inl
@@ -52,7 +52,7 @@ namespace FFPACK {
         size_t* P = FFLAS::fflas_new<size_t>(Na);
         size_t* Q = FFLAS::fflas_new<size_t>(Na);
 
-        size_t R = LUdivine (F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, Na, Na, A, lda, P, Q);
+        size_t R = PLUQ (F, FFLAS::FflasNonUnit, Na, Na, A, lda, P, Q);
 
         fgetrs (F, Side, M, N, R, A, lda, P, Q, B, ldb, info);
 
@@ -73,15 +73,15 @@ namespace FFPACK {
            int * info)
     {
 
-        size_t* P = FFLAS::fflas_new<size_t>(N);
-        size_t* Q = FFLAS::fflas_new<size_t>(M);
+        size_t* P = FFLAS::fflas_new<size_t>(M);
+        size_t* Q = FFLAS::fflas_new<size_t>(N);
 
-        size_t R = LUdivine (F, FFLAS::FflasNonUnit, FFLAS::FflasNoTrans, M, N, A, lda, P, Q);
+        size_t R = PLUQ (F, FFLAS::FflasNonUnit, M, N, A, lda, P, Q);
 
         fgetrs (F, Side, M, N, NRHS, R, A, lda, P, Q, X, ldx, B, ldb, info);
 
-        FFLAS::fflas_delete( P);
-        FFLAS::fflas_delete( Q);
+        FFLAS::fflas_delete (P);
+        FFLAS::fflas_delete (Q);
 
         return R;
     }

--- a/fflas-ffpack/ffpack/ffpack_fgetrs.inl
+++ b/fflas-ffpack/ffpack/ffpack_fgetrs.inl
@@ -79,7 +79,7 @@ namespace FFPACK {
                    M, R, F.one, A, lda , B, ldb);
 
                 // B <- B P^T
-            applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, M, 0, M, B, ldb, P);
+            applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, M, 0, N, B, ldb, P);
         }
     }
 

--- a/fflas-ffpack/ffpack/ffpack_fgetrs.inl
+++ b/fflas-ffpack/ffpack/ffpack_fgetrs.inl
@@ -122,7 +122,7 @@ namespace FFPACK {
                 FFLAS::fassign (F,R,NRHS,W,ldw,X,ldx);
                 FFLAS::fflas_delete (W);
 
-                FFLAS::fzero (F, N-R, NRHS, X+R, ldx);
+                FFLAS::fzero (F, N-R, NRHS, X+R*ldx, ldx);
 
                     // B <- Q^T B
                 applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans, NRHS, 0, N, X, ldx, Q);
@@ -146,7 +146,7 @@ namespace FFPACK {
                 ftrsm (F, FFLAS::FflasLeft, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit,
                        R, NRHS, F.one, A, lda , X, ldx);
 
-                FFLAS::fzero (F, N-M, NRHS, X+M, ldx);
+                FFLAS::fzero (F, N-M, NRHS, X+M*ldx, ldx);
 
                     // B <- Q^T B
                 applyP (F, FFLAS::FflasLeft, FFLAS::FflasTrans, NRHS, 0, N, X, ldx, Q);

--- a/fflas-ffpack/ffpack/ffpack_fgetrs.inl
+++ b/fflas-ffpack/ffpack/ffpack_fgetrs.inl
@@ -53,8 +53,8 @@ namespace FFPACK {
                    R, N, F.one, A, lda , B, ldb);
 
                 // Verifying that the system is consistent @todo: disable this check optionnally
-            fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, M-R, N, R, F.mOne, A+R*lda, lda, B, ldb, F.One, B+R*ldb, ldb);
-            if (! fiszero (F, M-R, N, B+R*ldb, ldb)) *info = 1;
+            fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, M-R, N, R, F.mOne, A+R*lda, lda, B, ldb, F.one, B+R*ldb, ldb);
+            if (! FFLAS::fiszero (F, M-R, N, B+R*ldb, ldb)) *info = 1;
 
                 // B <- U^-1 B
             ftrsm (F, FFLAS::FflasLeft, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit,
@@ -72,7 +72,7 @@ namespace FFPACK {
                    M, R, F.one, A, lda , B, ldb);
                 //  Verifying that the system is consistent @todo: disable this check optionnally
             fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, M, N-R, R, F.mOne, B, ldb, A+R, lda, F.one, B+R, ldb);
-            if (! fiszero (F, M, N-R, B+R, ldb)) *info = 1;
+            if (! FFLAS::fiszero (F, M, N-R, B+R, ldb)) *info = 1;
 
                 // B <- B L^-1
             ftrsm (F, FFLAS::FflasRight, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit,
@@ -113,7 +113,7 @@ namespace FFPACK {
 
                     // Verifying that the system is consistent @todo: disable this check optionnally
                 fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, M-R, NRHS, R, F.mOne, A+R*lda, lda, W, ldw, F.one, W+R*ldw, ldw);
-                if (! fiszero (F, M-R, NRHS, W+R*ldw, ldw)) *info = 1;
+                if (! FFLAS::fiszero (F, M-R, NRHS, W+R*ldw, ldw)) *info = 1;
 
                     // B <- U^-1 B
                 ftrsm (F, FFLAS::FflasLeft, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit,
@@ -140,7 +140,7 @@ namespace FFPACK {
 
                     // Verifying that the system is consistent @todo: disable this check optionnally
                 fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, M-R, NRHS, R, F.mOne, A+R*lda, lda, X, ldx, F.one, X+R*ldx, ldx);
-                if (! fiszero (F, M-R, NRHS, X+R*ldx, ldx)) *info = 1;
+                if (! FFLAS::fiszero (F, M-R, NRHS, X+R*ldx, ldx)) *info = 1;
 
                     // B <- U^-1 B
                 ftrsm (F, FFLAS::FflasLeft, FFLAS::FflasUpper, FFLAS::FflasNoTrans, FFLAS::FflasNonUnit,
@@ -159,7 +159,7 @@ namespace FFPACK {
             if (M < N) {
                 W = FFLAS::fflas_new (F, NRHS, N);
                 ldw = N;
-                fassign (F,NRHS, N, B, ldb, W, ldw);
+                FFLAS::fassign (F,NRHS, N, B, ldb, W, ldw);
 
                     // B <- B Q^T
                 applyP (F, FFLAS::FflasRight, FFLAS::FflasTrans, NRHS, 0, N, W, ldw, Q);
@@ -172,17 +172,17 @@ namespace FFPACK {
                 fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, NRHS, N-R, R, F.mOne,
                        W, ldw, A+R, lda, F.one, W+R, ldw);
 
-                if (! fiszero (F, NRHS, N-R, W+R, ldw)) *info = 1;
+                if (! FFLAS::fiszero (F, NRHS, N-R, W+R, ldw)) *info = 1;
 
                     // B <- B L^-1
                 ftrsm (F, FFLAS::FflasRight, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit,
                        NRHS, R, F.one, A, lda , W, ldw);
 
                     // X <- B
-                fassign (F, NRHS, R, W, ldw, X, ldx);
-                fflas_delete (W);
+                FFLAS::fassign (F, NRHS, R, W, ldw, X, ldx);
+                FFLAS::fflas_delete (W);
 
-                fzero (F, NRHS, M-R, X+R, ldx);
+                FFLAS::fzero (F, NRHS, M-R, X+R, ldx);
 
                     // X <- X P^T
                 applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, NRHS, 0, M, X, ldx, P);
@@ -201,7 +201,7 @@ namespace FFPACK {
                 fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, NRHS, N-R, R, F.mOne,
                        X, ldx, A+R, lda, F.one, X+R, ldx);
 
-                if (! fiszero (F, NRHS, N-R, X+R, ldx)) *info = 1;
+                if (! FFLAS::fiszero (F, NRHS, N-R, X+R, ldx)) *info = 1;
 
                 // B <- B L^-1
                 ftrsm (F, FFLAS::FflasRight, FFLAS::FflasLower, FFLAS::FflasNoTrans, FFLAS::FflasUnit,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -178,7 +178,7 @@ perfpublisher:
 # for compilation of new tests
 FFLASFFPACK_BIN=@bindir@
 
-new_examp_comp = $(CXX) $(AM_CXXFLAGS) ${CXXFLAGS}  ${INCLUDES} $(AM_CPPFLAGS) $^ -o $@ $(LDFLAGS) $(LDADD) $(LOADLIBES)
+new_examp_comp = $(CXX) $(AM_CXXFLAGS) ${CXXFLAGS}  ${INCLUDES} $(AM_CPPFLAGS) $^ -o $@ $(LDFLAGS) $(LDADD) $(LOADLIBES) $(LIBS)
 
 %:%.C
 	$(new_examp_comp)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ BASIC_TESTS =               \
 		test-io      \
 		test-maxdelayeddim \
 		test-solve \
+		test-fgesv             \
 		test-simd \
 		test-fgemv \
 		test-nullspace \
@@ -88,7 +89,6 @@ NOT_A_TEST =  \
 		test-krylov-elim       \
 		test-fullranksubmatrix \
 		test-frobenius         \
-		test-fgesv             \
 		test-invert            \
 		test-sparse
 
@@ -145,7 +145,7 @@ test_ftrtri_SOURCES            = test-ftrtri.C
 #  test_fullranksubmatrix_SOURCES = test-fullranksubmatrix.C
 #  test_invert_SOURCES            = test-invert.C
 #  test_krylov_elim_SOURCES       = test-krylov-elim.C
-#  test_fgesv_SOURCES             = test-fgesv.C
+test_fgesv_SOURCES             = test-fgesv.C
 #  test_frobenius_SOURCES         = test-frobenius.C
 test_nullspace_SOURCES = test-nullspace.C
 test_fdot_SOURCES = test-fdot.C

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -39,7 +39,7 @@ using namespace FFPACK;
 template <class Field,  class RandIter>
 bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, size_t m, size_t k, size_t r, RandIter& G){
 
-    typename Field::Element_ptr A, B, X, Acop, R;
+    typename Field::Element_ptr A, B, X, Acop, R=NULL;
     size_t lda, ldb, ldx, ldr, brows, bcols;
     if (side == FflasLeft){brows = m; bcols = k;}
     else {brows = k; bcols = m;}
@@ -93,7 +93,7 @@ bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, s
 template <class Field,  class RandIter>
 bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, size_t m, size_t n, size_t k, size_t r, RandIter& G){
 
-    typename Field::Element_ptr A, B, X, Acop, R;
+    typename Field::Element_ptr A, B, X, Acop, R=NULL;
     size_t lda, ldb, ldx, ldr, brows, bcols;
     if (side == FflasLeft) {brows = n; bcols = k;}
     else {brows = k; bcols = m;}

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -57,7 +57,7 @@ bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, s
         ldb = ldx = ldr = bcols;
     } else {
         ldb = ldx = ldr = bcols+(rand() % 13);
-        B = fflas_new (F, brows,bcols);
+        B = fflas_new (F, brows,ldb);
         if (r==m)
             RandomMatrix(F, brows, bcols, B, ldb, G);
         else{
@@ -69,8 +69,8 @@ bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, s
         }
     }
     Acop = fflas_new(F, m, lda);
-    X = fflas_new(F, brows, bcols);
-    R = fflas_new(F, brows, bcols);
+    X = fflas_new(F, brows, ldx);
+    R = fflas_new(F, brows, ldr);
     fassign (F, brows, bcols, B,ldb, X, ldx);
     fassign (F, m, m, A, lda, Acop, lda);
 
@@ -111,7 +111,7 @@ bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, siz
         ldb = ldx = ldr = bcols;
     } else {
         ldb = ldx = ldr = bcols+(rand() % 13);
-        B = fflas_new (F, brows,bcols);
+        B = fflas_new (F, brows,ldb);
         if (r==std::min(m,n))
             RandomMatrix(F, brows, bcols, B, ldb, G);
         else{
@@ -124,8 +124,8 @@ bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, siz
     }
 
     Acop = fflas_new(F, m, lda);
-    X = fflas_new(F, brows, bcols);
-    R = fflas_new(F, brows, bcols);
+    X = fflas_new(F, brows, ldx);
+    R = fflas_new(F, brows, ldr);
     fassign (F, brows, bcols, B,ldb, X, ldx);
     fassign (F, m, n, A, lda, Acop, lda);
 

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -31,14 +31,14 @@
 // Clement Pernet
 //-------------------------------------------------------------------------
 
-//#define __FFLASFFPACK_DEBUG 1
+#define __FFLASFFPACK_DEBUG 1
 #define TIME 1
 
 #include <iomanip>
 #include <iostream>
 using namespace std;
 
-#include "fflas-ffpack/field/modular-balanced.h"
+#include "givaro/modular-balanced.h"
 #include "fflas-ffpack/utils/timer.h"
 #include "fflas-ffpack/utils/fflas_io.h"
 #include "fflas-ffpack/ffpack/ffpack.h"
@@ -50,7 +50,7 @@ typedef Givaro::Modular<double> Field;
 
 int main(int argc, char** argv){
 
-    int n,m,mb,nb;
+    size_t  n,m,mb,nb;
     cerr<<setprecision(10);
 
     if (argc != 6)	{

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -241,10 +241,10 @@ int main(int argc, char** argv){
 
     Givaro::Integer q = -1;
     size_t b = 0;
-    size_t m = 197;
-    size_t n = 280;
+    size_t m = 257;
+    size_t n = 210;
     size_t k = 112;
-    size_t r = 107;
+    size_t r = 127;
     size_t iters = 4 ;
     bool loop=false;
     uint64_t seed = getSeed();

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -23,170 +23,243 @@
  *.
  */
 
-
-//--------------------------------------------------------------------------
-//                        Test for fgesv : 1 computation
-//
-//--------------------------------------------------------------------------
-// Clement Pernet
-//-------------------------------------------------------------------------
-
-#define __FFLASFFPACK_DEBUG 1
-#define TIME 1
-
-#include <iomanip>
 #include <iostream>
+#include <iomanip>
+#include "fflas-ffpack/fflas-ffpack.h"
+#include "fflas-ffpack/utils/args-parser.h"
+#include "fflas-ffpack/utils/test-utils.h"
+
+#include <givaro/modular.h>
+
 using namespace std;
-
-#include "givaro/modular-balanced.h"
-#include "fflas-ffpack/utils/timer.h"
-#include "fflas-ffpack/utils/fflas_io.h"
-#include "fflas-ffpack/ffpack/ffpack.h"
-
-
+using namespace FFLAS;
 using namespace FFPACK;
 
-typedef Givaro::Modular<double> Field;
+
+template <class Field,  class RandIter>
+bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, size_t m, size_t k, size_t r, RandIter& G){
+
+    typename Field::Element_ptr A, B, X, Acop, R;
+    size_t lda, ldb, ldx, ldr, brows, bcols;
+    if (side == FflasLeft){brows = m; bcols = k;}
+    else {brows = k; bcols = m;}
+    
+    if (!fileA.empty()){
+        ReadMatrix (fileA, F, m, m, A);
+        lda = m;
+    } else {
+        lda = m+(rand() % 13);
+        A = fflas_new (F, m,lda);
+        RandomMatrixWithRankandRandomRPM (F, m, m, r, A, lda, G);
+    }
+    if (!fileB.empty()){
+        ReadMatrix (fileB, F, brows, bcols, B);
+        ldb = ldx = ldr = bcols;
+    } else {
+        ldb = ldx = ldr = bcols+(rand() % 13);
+        B = fflas_new (F, brows,bcols);
+        if (r==m)
+            RandomMatrix(F, brows, bcols, B, ldb, G);
+        else{
+            RandomMatrix(F, brows, bcols, R, ldr, G);
+            if (side == FflasLeft)
+                fgemm (F, FflasNoTrans, FflasNoTrans, m, k, m, F.one, A, lda, R, ldr, F.zero, B, ldb);
+            else
+                fgemm (F, FflasNoTrans, FflasNoTrans, k, m, m, F.one, R, ldr, A, lda, F.zero, B, ldb);
+        }
+    }
+    Acop = fflas_new(F, m, lda);
+    X = fflas_new(F, brows, bcols);
+    R = fflas_new(F, brows, bcols);
+    fassign (F, brows, bcols, B,ldb, X, ldx);
+    fassign (F, m, m, A, lda, Acop, lda);
+
+    int info=0;
+    bool ok = true;
+    fgesv(F, side, brows, bcols, A, lda, X, ldx, &info);
+
+    if (side == FflasLeft)
+        fgemm (F, FflasNoTrans, FflasNoTrans, m, k, m, F.one, A, lda, X, ldx, F.zero, R, ldr);
+    else
+        fgemm (F, FflasNoTrans, FflasNoTrans, k, m, m, F.one, X, ldx, A, lda, F.zero, R, ldr);
+
+    ok = ok && fequal (F, brows, bcols, R, ldr, B, ldb) && (info == 0);
+    cout<<"...";
+
+    fflas_delete(A,B,X,Acop,R);
+    return ok;
+}
+
+template <class Field,  class RandIter>
+bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, size_t m, size_t n, size_t k, size_t r, RandIter& G){
+
+    typename Field::Element_ptr A, B, X, Acop, R;
+    size_t lda, ldb, ldx, ldr, brows, bcols;
+    if (side == FflasLeft) {brows = n; bcols = k;}
+    else {brows = k; bcols = m;}
+    
+    if (!fileA.empty()){
+        ReadMatrix (fileA, F, m, n, A);
+        lda = n;
+    } else {
+        lda = n+(rand() % 13);
+        A = fflas_new (F, m,lda);
+        RandomMatrixWithRankandRandomRPM (F, m, n, r, A, lda, G);
+    }
+    if (!fileB.empty()){
+        ReadMatrix (fileB, F, brows, bcols, B);
+        ldb = ldx = ldr = bcols;
+    } else {
+        ldb = ldx = ldr = bcols+(rand() % 13);
+        B = fflas_new (F, brows,bcols);
+        if (r==std::min(m,n))
+            RandomMatrix(F, brows, bcols, B, ldb, G);
+        else{
+            RandomMatrix(F, brows, bcols, R, ldr, G);
+            if (side == FflasLeft)
+                fgemm (F, FflasNoTrans, FflasNoTrans, m, k, n, F.one, A, lda, R, ldr, F.zero, B, ldb);
+            else
+                fgemm (F, FflasNoTrans, FflasNoTrans, k, n, m, F.one, R, ldr, A, lda, F.zero, B, ldb);
+        }
+    }
+
+    Acop = fflas_new(F, m, lda);
+    X = fflas_new(F, brows, bcols);
+    R = fflas_new(F, brows, bcols);
+    fassign (F, brows, bcols, B,ldb, X, ldx);
+    fassign (F, m, n, A, lda, Acop, lda);
+
+    int info=0;
+    bool ok = true;
+    fgesv(F, side, m, n, k, A, lda, X, ldx, B, ldb, &info);
+
+    if (side == FflasLeft)
+        fgemm (F, FflasNoTrans, FflasNoTrans, m, k, n, F.one, A, lda, X, ldx, F.zero, R, ldr);
+    else
+        fgemm (F, FflasNoTrans, FflasNoTrans, k, n, m, F.one, X, ldx, A, lda, F.zero, R, ldr);
+
+    ok = ok && fequal(F, brows, bcols, R, ldr, B, ldb) && (info == 0);
+    cout<<"...";
+
+    fflas_delete(A,B,X,Acop,R);
+    return ok;
+}
+template<class Field>
+bool run_with_field(Givaro::Integer q, uint64_t b, size_t m, size_t n, size_t k, size_t r, size_t iters, string fileA, string fileB,  uint64_t& seed){
+    bool ok = true ;
+    int nbit=(int)iters;
+
+    while (ok &&  nbit){
+        // choose Field
+        Field* F= chooseField<Field>(q,b,seed);
+        if (F==nullptr)
+            return true;
+        typename Field::RandIter G(*F,0,seed++);
+
+        ostringstream oss;
+        F->write(oss);
+
+        cout.fill('.');
+        cout<<"Checking ";
+        cout.width(40);
+        cout<<oss.str();
+        cout<<" ... ";
+
+        cout<<"FR.sq..";
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, m, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, m, G);
+        cout<<"FR.rect..";
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, m, n, k, std::min(m,n), G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, m, n, k, std::min(m,n), G);
+        cout<<"RD.sq..";
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, r, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, r, G);
+        cout<<"RD.rect..";
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, m, n, k, r, G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, m, n, k, r, G);
+
+
+        size_t MM = (rand() % m)+50;
+        size_t NN = (rand() % n)+50;
+        size_t KK = (rand() % k)+50;
+        size_t RR = (rand() % std::min(NN,MM));
+        cout<<"Random dim...";
+        cout<<"FR.sq..";
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, MM, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, MM, G);
+        cout<<"FR.rect..";
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
+        cout<<"RD.sq..";
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, RR, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, RR, G);
+        cout<<"RD.rect..";
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, RR, G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, RR, G);
+
+        delete F;
+
+        nbit--;
+        if (!ok)
+            cout << "FAILED "<<endl;
+        else
+            cout << "PASSED "<<endl;
+    }
+    return ok;
+}
+
 
 int main(int argc, char** argv){
+    cerr<<setprecision(20);
 
-    size_t  n,m,mb,nb;
-    cerr<<setprecision(10);
+    Givaro::Integer q = -1;
+    size_t b = 0;
+    size_t m = 197;
+    size_t n = 280;
+    size_t k = 112;
+    size_t r = 107;
+    size_t iters = 4 ;
+    bool loop=false;
+    uint64_t seed = getSeed();
+    string fileA = "";
+    string fileB = "";
+    Argument as[] = {
+        { 'q', "-q Q", "Set the field cardinality.",         TYPE_INTEGER , &q },
+        { 'b', "-b B", "Set the bitsize of the field characteristic.",  TYPE_INT , &b },
+        { 'm', "-m M", "Set the row dimension the system matrix A.", TYPE_INT , &m },
+        { 'n', "-n N N", "Set the column dimension of the system matrix.", TYPE_INT , &n },
+        { 'k', "-k K", "Set the dimension of the right/left-handside of the system.", TYPE_INT , &k },
+        { 'r', "-r R", "Set the rank of the matrix.", TYPE_INT , &r },
+        { 'i', "-i I", "Set number of repetitions.",            TYPE_INT , &iters },
+        { 'l', "-loop Y/N", "run the test in an infinite loop.", TYPE_BOOL , &loop },
+        { 's', "-s seed", "Set seed for the random generator", TYPE_UINT64, &seed },
+        { 'f', "-f fileA", "Set input file for system matrix A", TYPE_STR, &fileA },
+        { 'g', "-g fileB", "Set input file for right/left hand side matrix B", TYPE_STR, &fileB },
+        END_OF_ARGUMENTS
+    };
 
-    if (argc != 6)	{
-        cerr<<"Usage : test-fgesv <p> <A> <b> <iter> <left/right>"
-        <<endl;
-        exit(-1);
-    }
-    int nbit=atoi(argv[4]); // number of times the product is performed
-    Field F(atoi(argv[1]));
-    Field::Element * A, *B, *X=NULL;
-    FFLAS::ReadMatrix (argv[2],F,m,n,A);
-    FFLAS::ReadMatrix (argv[3],F,mb,nb,B);
+    FFLAS::parseArguments(argc,argv,as);
 
-    FFLAS::FFLAS_SIDE side = (atoi(argv[5])) ? FFLAS::FflasRight :  FFLAS::FflasLeft;
+    srand(seed);
+    cerr << "with seed = " << seed << endl;
+    if (r>std::min(m,n)) r=std::min(m,n);
+    bool ok=true;
+    do{
+        ok = ok && run_with_field<Givaro::Modular<float> >           (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::Modular<double> >          (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::ModularBalanced<float> >   (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::ModularBalanced<double> >  (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::Modular<int32_t> >         (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::ModularBalanced<int32_t> > (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::Modular<int64_t> >         (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::ModularBalanced<int64_t> > (q,b,m,n,k,r,iters,fileA, fileB,seed);
+        ok = ok && run_with_field<Givaro::Modular<Givaro::Integer> > (q,(b?b:128),m/4+1,n/4+1,k/4+1,r/4+1,iters,fileA, fileB,seed);
+    } while (loop && ok);
 
-    size_t ldx=0;
-    size_t rhs = (side == FFLAS::FflasLeft) ? nb : mb;
-    if (m != n) {
-        if (side == FFLAS::FflasLeft){
-            X = FFLAS::fflas_new<Field::Element>(n*nb);
-            ldx = nb;
-        }
-        else {
-            X = FFLAS::fflas_new<Field::Element>(mb*m);
-            ldx = m;
-        }
-    }
+    if (!ok) cerr << "with seed = " << seed << endl;
 
-    if ( ((side == FFLAS::FflasRight) && (n != nb))
-         || ((side == FFLAS::FflasLeft)&&(m != mb)) ) {
-        cerr<<"Error in the dimensions of the input matrices"<<endl;
-        exit(-1);
-    }
-    int info=0;
-    FFLAS::Timer t; t.clear();
-    double time=0.0;
-    //FFLAS::WriteMatrix (cerr<<"A="<<endl, F, k,k,A,k);
-    size_t R=0;
-    for (int i = 0;i<nbit;++i){
-        t.clear();
-        t.start();
-        if (m == n)
-            R = FFPACK::fgesv (F, side, mb, nb, A, n, B, nb, &info);
-        else
-            R = FFPACK::fgesv (F, side, m, n, rhs, A, n, X, ldx, B, nb, &info);
-        if (info > 0){
-            std::cerr<<"System is inconsistent"<<std::endl;
-            exit(-1);
-        }
-
-        t.stop();
-        time+=t.usertime();
-        if (i+1<nbit){
-            FFLAS::fflas_delete(A);
-            FFLAS::ReadMatrix (argv[2],F,m,n,A);
-            FFLAS::fflas_delete( B);
-            FFLAS::ReadMatrix (argv[3],F,mb,nb,B);
-        }
-    }
-
-#ifdef __FFLASFFPACK_DEBUG
-    Field::Element  *B2=NULL;
-    FFLAS::fflas_delete( A);
-
-    if (info > 0){
-        std::cerr<<"System inconsistent"<<std::endl;
-        exit (-1);
-    }
-
-    FFLAS::ReadMatrix (argv[2],F,m,n,A);
-
-    B2 = FFLAS::fflas_new<Field::Element>(mb*nb);
-
-
-    if (m==n)
-        if (side == FFLAS::FflasLeft)
-            FFLAS::fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, m, nb, n,
-                          F.one, A, n, B, nb, F.zero, B2, nb);
-        else
-            FFLAS::fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, mb, n, m,
-                          F.one, B, nb, A, n, F.zero, B2, nb);
-    else
-        if (side == FFLAS::FflasLeft)
-            FFLAS::fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, m, nb, n,
-                          F.one, A, n, X, ldx, F.zero, B2, nb);
-        else
-            FFLAS::fgemm (F, FFLAS::FflasNoTrans, FFLAS::FflasNoTrans, mb, n, m,
-                          F.one, X, ldx, A, n, F.zero, B2, nb);
-    FFLAS::fflas_delete( B);
-    FFLAS::fflas_delete( X);
-
-    FFLAS::ReadMatrix (argv[3],F,mb,nb,B);
-
-    bool wrong = false;
-    for (int i=0;i<mb;++i)
-        for (int j=0;j<nb;++j)
-            if ( !F.areEqual(*(B2+i*nb+j), *(B+i*nb+j))){
-                cerr<<"B2 ["<<i<<", "<<j<<"] = "<<(*(B2+i*nb+j))
-                <<" ; B ["<<i<<", "<<j<<"] = "<<(*(B+i*nb+j))
-                <<endl;
-                wrong = true;
-            }
-
-    if (wrong) {
-        cerr<<"FAIL"<<endl;
-        //FFLAS::WriteMatrix (cerr<<"B2="<<endl,F,m,n,B2,n);
-        //FFLAS::WriteMatrix (cerr<<"B="<<endl,F,m,n,B,n);
-    }else{
-
-        cerr<<"PASS"<<endl;
-    }
-
-
-    FFLAS::fflas_delete( B2);
-#endif
-
-    FFLAS::fflas_delete( A);
-    FFLAS::fflas_delete( B);
-#if TIME
-    double mflops;
-    double cplx = (double)n*m*m-(double)m*m*m/3;
-    if (side == FFLAS::FflasLeft)
-        mflops = (cplx+(double)(2*R*R*n))/1000000.0*nbit/time;
-    else
-        mflops = (cplx+(double)(2*R*R*m))/1000000.0*nbit/time;
-    cerr<<"m,n,mb,nb = "<<m<<" "<<n<<" "<<mb<<" "<<nb<<". fgesv "
-    <<((side == FFLAS::FflasLeft)?" Left ":" Right ")
-    <<"over Z/"<<atoi(argv[1])<<"Z :"
-    <<endl
-    <<"t= "
-    << time/nbit
-    << " s, Mffops = "<<mflops
-    << endl;
-
-    cout<<m<<" "<<n<<" "<<mflops<<" "<<time/nbit<<endl;
-#endif
+    return !ok;
 }
+
 /* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 // vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s

--- a/tests/test-fgesv.C
+++ b/tests/test-fgesv.C
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include "fflas-ffpack/utils/fflas_io.h"
 #include "fflas-ffpack/fflas-ffpack.h"
 #include "fflas-ffpack/utils/args-parser.h"
 #include "fflas-ffpack/utils/test-utils.h"
@@ -99,7 +100,7 @@ bool test_square_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, s
         WriteMatrix(std::cerr<<"B ="<<std::endl,F,brows,bcols,B,ldb);
         WriteMatrix(std::cerr<<"AX ="<<std::endl,F,brows,bcols,R,ldr);
     }
-    cout<<"...";
+    cout<<".";
 
     fflas_delete(A,B,X,Acop,R);
     return ok;
@@ -136,7 +137,7 @@ bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, siz
                 fgemm (F, FflasNoTrans, FflasNoTrans, m, k, n, F.one, A, lda, S, k, F.zero, B, ldb);
                 fflas_delete(S);
             } else {
-                typename Field::Element_ptr S = fflas_new(F, n, k);
+                typename Field::Element_ptr S = fflas_new(F, k, m);
                 RandomMatrix(F, k, m, S, m, G);
                 fgemm (F, FflasNoTrans, FflasNoTrans, k, n, m, F.one, S, m, A, lda, F.zero, B, ldb);
                 fflas_delete(S);
@@ -164,12 +165,12 @@ bool test_rect_fgesv (Field& F, FFLAS_SIDE side, string fileA, string fileB, siz
         if (side == FflasLeft) std::cerr<<"ERROR A X != B"<<std::endl;
         else std::cerr<<"ERROR X A != B"<<std::endl;
         WriteMatrix(std::cerr<<"A ="<<std::endl,F,m,n,Acop,lda);
-        WriteMatrix(std::cerr<<"X ="<<std::endl,F,brows,bcols,X,ldx);
+        WriteMatrix(std::cerr<<"X ="<<std::endl,F,xrows,xcols,X,ldx);
         WriteMatrix(std::cerr<<"B ="<<std::endl,F,brows,bcols,B,ldb);
         WriteMatrix(std::cerr<<"AX ="<<std::endl,F,brows,bcols,R,ldr);
     }
 
-    cout<<"...";
+    cout<<".";
 
     fflas_delete(A,B,X,Acop,R);
     return ok;
@@ -193,39 +194,35 @@ bool run_with_field(Givaro::Integer q, uint64_t b, size_t m, size_t n, size_t k,
         cout<<"Checking ";
         cout.width(40);
         cout<<oss.str();
-        cout<<" ... ";
+        cout<<" ...";
 
-        cout<<"FR.sq..";
-        // ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, m, G);
-        // ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, m, G);
-        // cout<<"FR.rect..";
-        // ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, m, n, k, std::min(m,n), G);
-        // ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, m, n, k, std::min(m,n), G);
-        // cout<<"RD.sq..";
-        // ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, r, G);
-        // ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, r, G);
-        // cout<<"RD.rect..";
+            // Full rank instances
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, m, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, m, G);
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, m, n, k, std::min(m,n), G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, m, n, k, std::min(m,n), G);
+            // Rank defficient instances
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, m, k, r, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, m, k, r, G);
         ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, m, n, k, r, G);
         ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, m, n, k, r, G);
 
 
-        // size_t MM = (rand() % m)+50;
-        // size_t NN = (rand() % n)+50;
-        // size_t KK = (rand() % k)+50;
-        // size_t RR = (rand() % std::min(NN,MM));
-        // cout<<"Random dim...";
-        // cout<<"FR.sq..";
-        // ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, MM, G);
-        // ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, MM, G);
-        // cout<<"FR.rect..";
-        // ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
-        // ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
-        // cout<<"RD.sq..";
-        // ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, RR, G);
-        // ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, RR, G);
-        // cout<<"RD.rect..";
-        // ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, RR, G);
-        // ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, RR, G);
+            // Randomized dimensions
+        size_t MM = (rand() % m)+50;
+        size_t NN = (rand() % n)+50;
+        size_t KK = (rand() % k)+50;
+        size_t RR = (rand() % std::min(NN,MM));
+            // Full rank instances
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, MM, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, MM, G);
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, std::min(MM,NN), G);
+            // Rank defficient instances
+        ok = ok && test_square_fgesv (*F, FflasLeft, fileA, fileB, MM, KK, RR, G);
+        ok = ok && test_square_fgesv (*F, FflasRight, fileA, fileB, MM, KK, RR, G);
+        ok = ok && test_rect_fgesv (*F, FflasLeft, fileA, fileB, MM, NN, KK, RR, G);
+        ok = ok && test_rect_fgesv (*F, FflasRight, fileA, fileB, MM, NN, KK, RR, G);
 
         delete F;
 

--- a/tests/test-nullspace.C
+++ b/tests/test-nullspace.C
@@ -101,7 +101,6 @@ bool test_nullspace(Field& F, FFLAS::FFLAS_SIDE side, size_t m, size_t n, size_t
     if (side == FFLAS::FFLAS_SIDE::FflasRight) {
         // Right nullspace dimension + Rank == Matrix column dimension
         if (NSdim + r != n) return false;
-
         // Ensure nullspace is full rank
         auto NSCopy = FFLAS::fflas_new(F, n, NSdim);
         FFLAS::fassign(F, n, NSdim, NS, NSdim, NSCopy, NSdim);


### PR DESCRIPTION
Fixing #229 
- Changes all calls to LUdivine into calls to PLUQ, except `isSingular` and `MinPoly` which benefit from the special shape of LUdivine slab elimination.
- fix all algorithms accordingly
- add a proper test-suite for `gesv` and `fgetrs` who were not being tested