### PR TITLE
uncomment non-vectorised fast helper-based reduce; some cleanup

### DIFF
--- a/fflas-ffpack/fflas/fflas_freduce.inl
+++ b/fflas-ffpack/fflas/fflas_freduce.inl
@@ -33,7 +33,6 @@
 #include <givaro/udl.h>
 
 #include "fflas-ffpack/fflas/fflas_fassign.h"
-#include "fflas-ffpack/utils/bit_manipulation.h"
 
 #define FFLASFFPACK_COPY_REDUCE 32 /*  TO BENCMARK LATER */
 
@@ -89,39 +88,6 @@ namespace FFLAS { namespace vectorised { /*  for casts (?) */
     inline RecInt::rmint<K,MG>& reduce(RecInt::rmint<K,MG>& A, RecInt::rmint<K,MG>& B)
     {
         return RecInt::rmint<K>::mod_n(A, B);
-    }
-
-    template<class T>
-    inline typename std::enable_if< ! std::is_integral<T>::value, T>::type
-    monrint(T A)// @bug pass by reference ?
-    {
-        return rint(A);
-    }
-
-    template<class T>
-    inline typename std::enable_if< std::is_integral<T>::value, T>::type
-    monrint( T A)
-    {
-        return A ;
-    }
-
-    template<>
-    inline double monrint(double A)
-    {
-        return rint(A);
-    }
-
-
-    template<>
-    inline float monrint(float A)
-    {
-        return rintf(A);
-    }
-
-    template<>
-    inline Givaro::Integer monrint(Givaro::Integer A) // @bug B is not integer, but uint64_t usually
-    {
-        return A ; // B > 0
     }
 
     inline int64_t reduce(int64_t A, int64_t p, double invp, double min, double max, int64_t pow50rem)
@@ -396,7 +362,6 @@ namespace FFLAS { namespace vectorised {
 
 namespace FFLAS  { namespace vectorised { namespace unswitch  {
 
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
     template<class Field>
     inline typename std::enable_if<FFLAS::support_simd_mod<typename Field::Element>::value, void>::type
     modp(const Field &F, typename Field::ConstElement_ptr U, const size_t & n,
@@ -420,7 +385,7 @@ namespace FFLAS  { namespace vectorised { namespace unswitch  {
             for (; i < n ; i++)
             {
                 T[i]=reduce<Field>(U[i],H);
-                if (!positive)
+                if (!positive) //TODO check that can be removed
                 {
                     T[i]-=(T[i]>max)?H.p:0;
                 }
@@ -440,7 +405,7 @@ namespace FFLAS  { namespace vectorised { namespace unswitch  {
             for (size_t j = static_cast<size_t>(st) ; j < simd::alignment ; j += sizeof(Element), i++)
             {
                 T[i] = reduce<Field>(U[i],H);
-                if (!positive)
+                if (!positive) // TODO ditto
                 {
                     T[i] -= (T[i] > max) ? H.p : 0;
                 }
@@ -470,18 +435,16 @@ namespace FFLAS  { namespace vectorised { namespace unswitch  {
         {
 
             T[i] = reduce<Field>(U[i],H);
-            if (!positive)
+            if (!positive) // TODO ditto
             {
                 T[i] -= (T[i] > max) ? H.p : 0;
             }
             T[i] += (T[i] < min) ? H.p : 0;
         }
     }
-#endif
 
-    /* Not used? PK - 2019
     // not vectorised but allows better code than % or fmod via helper
-    template<class Field, bool round, int algo>
+    template<class Field>
     inline typename std::enable_if< !FFLAS::support_simd_mod<typename Field::Element>::value, void>::type
     modp(const Field &F, typename Field::ConstElement_ptr U, const size_t & n,
          typename Field::Element_ptr T
@@ -496,24 +459,14 @@ namespace FFLAS  { namespace vectorised { namespace unswitch  {
         size_t i = 0;
         for (; i < n ; i++)
         {
-            if (round)
-            {
-                T[i] = monrint(U[i]);
-                T[i] = reduce<Field,algo>(T[i],H);
-            }
-            else
-            {
-                T[i]=reduce<Field,algo>(U[i],H);
-            }
-            if (!positive)
+            T[i]=reduce<Field>(U[i],H);
+            if (!positive) // TODO ditto
             {
                 T[i]-=(T[i]>max)?H.p:(typename Field::Element)0;
             }
             T[i]+=(T[i]<min)?H.p:(typename Field::Element)0;
         }
     }
-    */
-
 } // unswitch
 } // vectorised
 } // FFLAS


### PR DESCRIPTION
Uncomment and patch the non-vectorised version of `unswitch::modp`.

There is still some cleanup that can be done (or ruled out) in `fflas_freduce.inl`, but it's probably better to do this bugfix on its own and not to wait for possible later improvements.