### PR TITLE
self-standing parallel routine named pSolve for the routine Solve added and cleaned up

### DIFF
--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -1273,6 +1273,12 @@ namespace FFPACK { /* Solutions */
            typename Field::Element_ptr x, const int incx,
            typename Field::ConstElement_ptr b, const int incb, PSHelper& psH);
 
+    template <class Field>
+    typename Field::Element_ptr
+    pSolve( const Field& F, const size_t M,
+           typename Field::Element_ptr A, const size_t lda,
+           typename Field::Element_ptr x, const int incx,
+           typename Field::ConstElement_ptr b, const int incb );
 
     //! Solve L X = B or X L = B in place.
     //! L is M*M if Side == FFLAS::FflasLeft and N*N if Side == FFLAS::FflasRight, B is M*N.

--- a/fflas-ffpack/ffpack/ffpack.inl
+++ b/fflas-ffpack/ffpack/ffpack.inl
@@ -166,6 +166,20 @@ namespace FFPACK {
     }
 
     template <class Field>
+    inline typename Field::Element_ptr
+    pSolve (const Field& F, const size_t M,
+           typename Field::Element_ptr A, const size_t lda,
+           typename Field::Element_ptr x, const int incx,
+           typename Field::ConstElement_ptr b, const int incb) {
+           FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
+            PAR_BLOCK{
+                parH.set_numthreads(NUM_THREADS);
+                FFPACK::Solve(F, M, A, lda, x, incx, b, incb, parH);
+            }
+            return x;
+    }
+
+    template <class Field>
     void RandomNullSpaceVector (const Field& F, const FFLAS::FFLAS_SIDE Side,
                                 const size_t M, const size_t N,
                                 typename Field::Element_ptr A, const size_t lda,

--- a/tests/test-solve.C
+++ b/tests/test-solve.C
@@ -150,8 +150,8 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t m, size_t iters, uint64
 
             // testing a parallel run
         std::cout<<" par: ";
-        FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
-        ok = ok && check_solve(*F,m,G, parH);
+        ok = ok && check_solve(*F,m,G,
+        FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads>());
 
         std::cout<<std::endl;
         nbit--;


### PR DESCRIPTION
A function named pSolve has been added for the parallel execution using an empirical ParSeqHelper for the Solve function which could be used as self-standing parallel solve routine in the SageMaths.