### PR TITLE
Wrapped PLUQ into pPLUQ without the need to use PAR_BLOCK for labelling the parallel region

### DIFF
--- a/benchmarks/benchmark-pluq.C
+++ b/benchmarks/benchmark-pluq.C
@@ -243,11 +243,13 @@ int main(int argc, char** argv) {
 
         if (i) chrono.start();
         if (par){
-
+/*
             PAR_BLOCK{
                 parH.set_numthreads(t);
                 R = FFPACK::PLUQ(F, diag, m, n, A, n, P, Q, parH);
             }
+*/
+            R = FFPACK::pPLUQ(F, diag, m, n, A, n, P, Q);
         }
         else{
             if (slab)

--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -592,6 +592,12 @@ namespace FFPACK {
                  size_t*P, size_t *Q);
 
     template<class Field>
+    size_t pPLUQ (const Field& F, const FFLAS::FFLAS_DIAG Diag,
+                 const size_t M, const size_t N,
+                 typename Field::Element_ptr A, const size_t lda,
+                 size_t*P, size_t *Q);
+
+    template<class Field>
     size_t PLUQ (const Field& F, const FFLAS::FFLAS_DIAG Diag,
                  const size_t M, const size_t N,
                  typename Field::Element_ptr A, const size_t lda,

--- a/fflas-ffpack/ffpack/ffpack_ppluq.inl
+++ b/fflas-ffpack/ffpack/ffpack_ppluq.inl
@@ -407,6 +407,22 @@ namespace FFPACK {
                     //#endif
     }
 
+    template<class Field>
+    inline size_t
+    pPLUQ (const Field& Fi, const FFLAS::FFLAS_DIAG Diag,
+          size_t M, size_t N,
+          typename Field::Element_ptr A, size_t lda, size_t*P, size_t *Q)
+    {
+        size_t r;
+        FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,
+                                    FFLAS::StrategyParameter::Threads> PSHelper;
+        PAR_BLOCK{
+            PSHelper.set_numthreads(NUM_THREADS);
+            r = FFPACK::PLUQ (Fi,Diag,M,N,A,lda,P,Q,PSHelper);
+        }
+        return r;
+    }
+
 }// namespace FFPACK
 
 //#endif // OPENMP


### PR DESCRIPTION
Wrapped the PLUQ into pPLUQ as required so that no more need to use a PAR_BLOCK to label the parallel region