### PR TITLE
Wrappped EchelonForm related functions into their parallel routines with no more need for PAR_BLOCK

### DIFF
--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -738,7 +738,7 @@ namespace FFPACK { /* echelon */
     pColumnEchelonForm (const Field& F, const size_t M, const size_t N,
                        typename Field::Element_ptr A, const size_t lda,
                        size_t* P, size_t* Qt, bool transform=false,
-                       const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+                       const FFPACK_LU_TAG LuTag=FfpackTileRecursive);
 
     template <class Field, class PSHelper>
     size_t
@@ -781,7 +781,7 @@ namespace FFPACK { /* echelon */
     pRowEchelonForm (const Field& F, const size_t M, const size_t N,
                     typename Field::Element_ptr A, const size_t lda,
                     size_t* P, size_t* Qt, const bool transform=false,
-                    const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+                    const FFPACK_LU_TAG LuTag=FfpackTileRecursive);
 
     template <class Field, class PSHelper>
     size_t
@@ -822,7 +822,7 @@ namespace FFPACK { /* echelon */
     pReducedColumnEchelonForm (const Field& F, const size_t M, const size_t N,
                               typename Field::Element_ptr A, const size_t lda,
                               size_t* P, size_t* Qt, const bool transform = false,
-                              const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+                              const FFPACK_LU_TAG LuTag=FfpackTileRecursive);
 
     template <class Field, class PSHelper>
     size_t
@@ -863,7 +863,7 @@ namespace FFPACK { /* echelon */
     pReducedRowEchelonForm (const Field& F, const size_t M, const size_t N,
                            typename Field::Element_ptr A, const size_t lda,
                            size_t* P, size_t* Qt, const bool transform = false,
-                           const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+                           const FFPACK_LU_TAG LuTag=FfpackTileRecursive);
 
     template <class Field, class PSHelper>
     size_t

--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -733,6 +733,13 @@ namespace FFPACK { /* echelon */
                        size_t* P, size_t* Qt, bool transform=false,
                        const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
 
+    template <class Field>
+    size_t
+    pColumnEchelonForm (const Field& F, const size_t M, const size_t N,
+                       typename Field::Element_ptr A, const size_t lda,
+                       size_t* P, size_t* Qt, bool transform=false,
+                       const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+
     template <class Field, class PSHelper>
     size_t
     ColumnEchelonForm (const Field& F, const size_t M, const size_t N,
@@ -765,6 +772,13 @@ namespace FFPACK { /* echelon */
     template <class Field>
     size_t
     RowEchelonForm (const Field& F, const size_t M, const size_t N,
+                    typename Field::Element_ptr A, const size_t lda,
+                    size_t* P, size_t* Qt, const bool transform=false,
+                    const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+
+    template <class Field>
+    size_t
+    pRowEchelonForm (const Field& F, const size_t M, const size_t N,
                     typename Field::Element_ptr A, const size_t lda,
                     size_t* P, size_t* Qt, const bool transform=false,
                     const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
@@ -803,6 +817,13 @@ namespace FFPACK { /* echelon */
                               size_t* P, size_t* Qt, const bool transform = false,
                               const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
 
+    template <class Field>
+    size_t
+    pReducedColumnEchelonForm (const Field& F, const size_t M, const size_t N,
+                              typename Field::Element_ptr A, const size_t lda,
+                              size_t* P, size_t* Qt, const bool transform = false,
+                              const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
+
     template <class Field, class PSHelper>
     size_t
     ReducedColumnEchelonForm (const Field& F, const size_t M, const size_t N,
@@ -837,6 +858,12 @@ namespace FFPACK { /* echelon */
                            size_t* P, size_t* Qt, const bool transform = false,
                            const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
 
+    template <class Field>
+    size_t
+    pReducedRowEchelonForm (const Field& F, const size_t M, const size_t N,
+                           typename Field::Element_ptr A, const size_t lda,
+                           size_t* P, size_t* Qt, const bool transform = false,
+                           const FFPACK_LU_TAG LuTag=FfpackSlabRecursive);
 
     template <class Field, class PSHelper>
     size_t

--- a/fflas-ffpack/ffpack/ffpack_echelonforms.inl
+++ b/fflas-ffpack/ffpack/ffpack_echelonforms.inl
@@ -41,6 +41,21 @@ inline size_t FFPACK::ColumnEchelonForm (const Field& F, const size_t M, const s
     return FFPACK::ColumnEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, seqH);
 }
 
+template <class Field>
+inline size_t FFPACK::pColumnEchelonForm (const Field& F, const size_t M, const size_t N,
+                                         typename Field::Element_ptr A, const size_t lda,
+                                         size_t* P, size_t* Qt, const bool transform,
+                                         const FFPACK_LU_TAG LuTag)
+{
+    size_t r;
+    FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
+    PAR_BLOCK{
+        parH.set_numthreads(NUM_THREADS);
+        r = FFPACK::ColumnEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, parH);
+    }
+    return r;
+}
+
 template <class Field, class PSHelper>
 inline size_t FFPACK::ColumnEchelonForm (const Field& F, const size_t M, const size_t N,
                                          typename Field::Element_ptr A, const size_t lda,
@@ -71,6 +86,21 @@ inline size_t FFPACK::RowEchelonForm (const Field& F, const size_t M, const size
 {
     FFLAS::ParSeqHelper::Sequential seqH;
     return FFPACK::RowEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, seqH);
+}
+
+template <class Field>
+inline size_t FFPACK::pRowEchelonForm (const Field& F, const size_t M, const size_t N,
+                                         typename Field::Element_ptr A, const size_t lda,
+                                         size_t* P, size_t* Qt, const bool transform,
+                                         const FFPACK_LU_TAG LuTag)
+{
+    size_t r;
+    FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
+    PAR_BLOCK{
+        parH.set_numthreads(NUM_THREADS);
+        r = FFPACK::RowEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, parH);
+    }
+    return r;
 }
 
 template <class Field, class PSHelper>
@@ -104,6 +134,22 @@ FFPACK::ReducedColumnEchelonForm (const Field& F, const size_t M, const size_t N
 {
     FFLAS::ParSeqHelper::Sequential seqH;
     return ReducedColumnEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, seqH);
+}
+
+template <class Field>
+inline size_t
+FFPACK::pReducedColumnEchelonForm (const Field& F, const size_t M, const size_t N,
+                                  typename Field::Element_ptr A, const size_t lda,
+                                  size_t* P, size_t* Qt, const bool transform,
+                                  const FFPACK_LU_TAG LuTag)
+{
+    size_t r;
+    FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
+    PAR_BLOCK{
+        parH.set_numthreads(NUM_THREADS);
+        r = ReducedColumnEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, parH);
+    }
+    return r;
 }
 
 template <class Field, class PSHelper>
@@ -147,6 +193,22 @@ FFPACK::ReducedRowEchelonForm (const Field& F, const size_t M, const size_t N,
 {
     FFLAS::ParSeqHelper::Sequential seqH;
     return ReducedRowEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, seqH);
+}
+
+template <class Field>
+inline size_t
+FFPACK::pReducedRowEchelonForm (const Field& F, const size_t M, const size_t N,
+                               typename Field::Element_ptr A, const size_t lda,
+                               size_t* P, size_t* Qt, const bool transform,
+                               const FFPACK_LU_TAG LuTag)
+{
+    size_t r;
+    FFLAS::ParSeqHelper::Parallel<FFLAS::CuttingStrategy::Recursive,FFLAS::StrategyParameter::Threads> parH;
+    PAR_BLOCK{
+        parH.set_numthreads(NUM_THREADS);
+        r = ReducedRowEchelonForm (F, M, N, A, lda, P, Qt, transform, LuTag, parH);
+    }
+    return r;
 }
 
 template <class Field, class PSHelper>

--- a/fflas-ffpack/interfaces/libs/ffpack.C
+++ b/fflas-ffpack/interfaces/libs/ffpack.C
@@ -584,6 +584,213 @@ ReducedRowEchelonForm_modular_int32_t (const int32_t p, const size_t M, const si
     }
 }
 
+size_t
+pColumnEchelonForm_modular_double (const double p, const size_t M, const size_t N,
+                                  double * A, const size_t lda,
+                                  size_t* P, size_t* Qt, bool transform ,
+                                  const enum FFPACK_C_LU_TAG LuTag
+                                  , bool positive)
+{
+    if (positive) {
+        Modular<double> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<double> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+size_t
+pRowEchelonForm_modular_double (const double p, const size_t M, const size_t N,
+                               double * A, const size_t lda,
+                               size_t* P, size_t* Qt, const bool transform,
+                               const enum FFPACK_C_LU_TAG LuTag
+                               , bool positive)
+{
+    if (positive) {
+        Modular<double> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<double> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedColumnEchelonForm_modular_double (const double p, const size_t M, const size_t N,
+                                         double * A, const size_t lda,
+                                         size_t* P, size_t* Qt, const bool transform,
+                                         const enum FFPACK_C_LU_TAG LuTag
+                                         , bool positive)
+{
+    if (positive) {
+        Modular<double> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<double> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedRowEchelonForm_modular_double (const double p, const size_t M, const size_t N,
+                                      double * A, const size_t lda,
+                                      size_t* P, size_t* Qt, const bool transform,
+                                      const enum FFPACK_C_LU_TAG LuTag
+                                      , bool positive)
+{
+    if (positive) {
+        Modular<double> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<double> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+size_t
+pColumnEchelonForm_modular_float (const float p, const size_t M, const size_t N,
+                                 float * A, const size_t lda,
+                                 size_t* P, size_t* Qt, bool transform ,
+                                 const enum FFPACK_C_LU_TAG LuTag
+                                 , bool positive)
+{
+    if (positive) {
+        Modular<float> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<float> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+size_t
+pRowEchelonForm_modular_float (const float p, const size_t M, const size_t N,
+                              float * A, const size_t lda,
+                              size_t* P, size_t* Qt, const bool transform,
+                              const enum FFPACK_C_LU_TAG LuTag
+                              , bool positive)
+{
+    if (positive) {
+        Modular<float> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<float> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedColumnEchelonForm_modular_float (const float p, const size_t M, const size_t N,
+                                        float * A, const size_t lda,
+                                        size_t* P, size_t* Qt, const bool transform,
+                                        const enum FFPACK_C_LU_TAG LuTag
+                                        , bool positive)
+{
+    if (positive) {
+        Modular<float> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<float> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedRowEchelonForm_modular_float (const float p, const size_t M, const size_t N,
+                                     float * A, const size_t lda,
+                                     size_t* P, size_t* Qt, const bool transform,
+                                     const enum FFPACK_C_LU_TAG LuTag
+                                     , bool positive)
+{
+    if (positive) {
+        Modular<float> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<float> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+size_t
+pColumnEchelonForm_modular_int32_t (const int32_t p, const size_t M, const size_t N,
+                                   int32_t * A, const size_t lda,
+                                   size_t* P, size_t* Qt, bool transform ,
+                                   const enum FFPACK_C_LU_TAG LuTag
+                                   , bool positive)
+{
+    if (positive) {
+        Modular<int32_t> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<int32_t> F(p);
+        return pColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+size_t
+pRowEchelonForm_modular_int32_t (const int32_t p, const size_t M, const size_t N,
+                                int32_t * A, const size_t lda,
+                                size_t* P, size_t* Qt, const bool transform,
+                                const enum FFPACK_C_LU_TAG LuTag
+                                , bool positive)
+{
+    if (positive) {
+        Modular<int32_t> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<int32_t> F(p);
+        return pRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedColumnEchelonForm_modular_int32_t (const int32_t p, const size_t M, const size_t N,
+                                          int32_t * A, const size_t lda,
+                                          size_t* P, size_t* Qt, const bool transform,
+                                          const enum FFPACK_C_LU_TAG LuTag
+                                          , bool positive)
+{
+    if (positive) {
+        Modular<int32_t> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<int32_t> F(p);
+        return pReducedColumnEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
+
+
+size_t
+pReducedRowEchelonForm_modular_int32_t (const int32_t p, const size_t M, const size_t N,
+                                       int32_t * A, const size_t lda,
+                                       size_t* P, size_t* Qt, const bool transform,
+                                       const enum FFPACK_C_LU_TAG LuTag
+                                       , bool positive)
+{
+    if (positive) {
+        Modular<int32_t> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    } else {
+        ModularBalanced<int32_t> F(p);
+        return pReducedRowEchelonForm(F,M,N,A,lda,P,Qt,transform,(enum FFPACK::FFPACK_LU_TAG)LuTag);
+    }
+}
+
 
 
 

--- a/fflas-ffpack/interfaces/libs/ffpack_compiled_spec.inl
+++ b/fflas-ffpack/interfaces/libs/ffpack_compiled_spec.inl
@@ -41,6 +41,35 @@ namespace FFPACK{
                                   const FFPACK::FFPACK_LU_TAG LuTag){
         return NAME(ReducedRowEchelonForm_modular) (F.cardinality(), M, N, A, lda, P, Qt, transform, LuTag, FFLAS_POSITIVE);
     }
+        // Parallel versions
+    template <>
+    size_t pColumnEchelonForm (const  Givaro::FFLAS_FIELD<FFLAS_TYPE>& F, const size_t M, const size_t N,
+                              FFLAS_TYPE* A, const size_t lda,
+                              size_t* P, size_t* Qt, bool transform,
+                              const FFPACK::FFPACK_LU_TAG LuTag){
+        return NAME(pColumnEchelonForm_modular) (F.cardinality(), M, N, A, lda, P, Qt, transform, LuTag, FFLAS_POSITIVE);
+    }
+    template <>
+    size_t pRowEchelonForm (const Givaro::FFLAS_FIELD<FFLAS_TYPE>& F, const size_t M, const size_t N,
+                           FFLAS_TYPE* A, const size_t lda,
+                           size_t* P, size_t* Qt, bool transform,
+                           const FFPACK::FFPACK_LU_TAG LuTag){
+        return NAME(pRowEchelonForm_modular) (F.cardinality(), M, N, A, lda, P, Qt, transform, LuTag, FFLAS_POSITIVE);
+    }
+    template <>
+    size_t pReducedColumnEchelonForm (const Givaro::FFLAS_FIELD<FFLAS_TYPE>& F, const size_t M, const size_t N,
+                                     FFLAS_TYPE* A, const size_t lda,
+                                     size_t* P, size_t* Qt, bool transform,
+                                     const FFPACK::FFPACK_LU_TAG LuTag){
+        return NAME(pReducedColumnEchelonForm_modular) (F.cardinality(), M, N, A, lda, P, Qt, transform, LuTag, FFLAS_POSITIVE);
+    }
+    template <>
+    size_t pReducedRowEchelonForm (const Givaro::FFLAS_FIELD<FFLAS_TYPE>& F, const size_t M, const size_t N,
+                                  FFLAS_TYPE* A, const size_t lda,
+                                  size_t* P, size_t* Qt, bool transform,
+                                  const FFPACK::FFPACK_LU_TAG LuTag){
+        return NAME(pReducedRowEchelonForm_modular) (F.cardinality(), M, N, A, lda, P, Qt, transform, LuTag, FFLAS_POSITIVE);
+    }
 }
 
 #undef FFLAS_POSITIVE

--- a/tests/test-echelon.C
+++ b/tests/test-echelon.C
@@ -56,7 +56,7 @@ using Givaro::ModularBalanced;
 
 template<class Field, class RandIter>
 bool
-test_colechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G)
+test_colechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G, bool par)
 {
     typedef typename Field::Element Element ;
     Element * A = FFLAS::fflas_new (F,m,n);
@@ -79,9 +79,10 @@ test_colechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FF
         
         for (size_t j=0;j<n;j++) P[j]=0;
         for (size_t j=0;j<m;j++) Q[j]=0;
-
-        R = FFPACK::ColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
-
+        if(!par)
+            R = FFPACK::ColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        else
+            R = FFPACK::pColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
         if (R != r) {pass = false; break;}
 
         FFPACK::getEchelonTransform (F, FFLAS::FflasLower, FFLAS::FflasUnit, m,n,R,P,Q,A,lda,U,n, LuTag);
@@ -130,7 +131,7 @@ test_colechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FF
 
 template<class Field, class RandIter>
 bool
-test_rowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G)
+test_rowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G, bool par)
 {
     typedef typename Field::Element Element ;
     Element * A = FFLAS::fflas_new (F,m,n);
@@ -154,7 +155,10 @@ test_rowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FF
         for (size_t j=0;j<m;j++) P[j]=0;
         for (size_t j=0;j<n;j++) Q[j]=0;
 
-        R = FFPACK::RowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        if(!par)
+            R = FFPACK::RowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        else
+            R = FFPACK::pRowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
 
         if (R != r) {pass = false; break;}
 
@@ -203,7 +207,7 @@ test_rowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FF
 
 template<class Field, class RandIter>
 bool
-test_redcolechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G)
+test_redcolechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G, bool par)
 {
     typedef typename Field::Element Element ;
     Element * A = FFLAS::fflas_new (F,m,n);
@@ -226,7 +230,10 @@ test_redcolechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK:
         for (size_t j=0;j<n;j++) P[j]=0;
         for (size_t j=0;j<m;j++) Q[j]=0;
 
-        R = FFPACK::ReducedColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        if(!par)
+            R = FFPACK::ReducedColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        else
+            R = FFPACK::pReducedColumnEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
 
         if (R != r) {pass = false; break;}
 
@@ -270,7 +277,7 @@ test_redcolechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK:
 }
 template<class Field, class RandIter>
 bool
-test_redrowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G)
+test_redrowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK::FFPACK_LU_TAG LuTag, RandIter& G, bool par)
 {
     typedef typename Field::Element Element ;
     Element * A = FFLAS::fflas_new (F,m,n);
@@ -297,7 +304,12 @@ test_redrowechelon(Field &F, size_t m, size_t n, size_t r, size_t iters, FFPACK:
         for (size_t j=0;j<m;j++) P[j]=0;
         for (size_t j=0;j<n;j++) Q[j]=0;
 
-        R = FFPACK::ReducedRowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        if(!par)
+            R = FFPACK::ReducedRowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+        else
+            R = FFPACK::pReducedRowEchelonForm (F, m, n, A, n, P, Q, true, LuTag);
+
+
         if (R != r) {pass = false; break;}
 
         FFPACK::getReducedEchelonTransform (F, FFLAS::FflasUpper, m,n,R,P,Q,A,lda,L,m, LuTag);
@@ -368,25 +380,46 @@ bool run_with_field (Givaro::Integer q, uint64_t b, size_t m, size_t n, size_t r
         std::cout<<oss.str();
         std::cout<<" .";
 
-        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G);
+        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G);
+        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G);
+        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G);
+        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G);
+        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G);
+        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G);
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G);
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, false);
         std::cout<<".";
-        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanSlab, G);
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanSlab, G, false);
         std::cout<<".";
-        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanTile, G);
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanTile, G, false);
+        std::cout<<".";
+
+        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_colechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_redcolechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_rowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackSlabRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackTileRecursive, G, true);
+        std::cout<<".";
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanSlab, G, true);
+        std::cout<<".";
+        ok = ok && test_redrowechelon(*F,m,n,r,iters, FFPACK::FfpackGaussJordanTile, G, true);
         std::cout<<".";
 
         nbit--;


### PR DESCRIPTION
Wrappped EchelonForm related functions such as RowEchelonForm into pRowEchelonForm to get rid of putting the PAR_BLOCK,  RowEchelonForm and  ColumnEchelonForm as well as ReducedRowEchelonForm and ReducedColumnEchelonForm are wrapped respectively.