### PR TITLE
ArithProg Charpoly: separate preconditionner from main algorithm

### DIFF
--- a/autotune/arithprog.C
+++ b/autotune/arithprog.C
@@ -80,7 +80,7 @@ int main (int argc, char** argv) {
     << "Threshold for ArithProg CharPoly algorithm";
     F.write(cerr << " (using ") << ')' << endl << endl;
 
-    cerr << "Charpoly:  n = "<<dim<<"  block_size   seconds            Gfops"<< std::endl;
+    cerr << "Charpoly:  n = "<<dim<<"  degree    seconds            Gfops"<< std::endl;
     double CurrTime;
     double PrevTime = 1000000;
     double BestTime = 1000000;
@@ -90,7 +90,7 @@ int main (int argc, char** argv) {
         //warm up computation
         std::list<Polynomial> charp_list;
         try{
-            Protected::CharpolyArithProg (PolDom, charp_list, dim, A, lda, g, n);
+            Protected::CharpolyArithProgKrylovPrecond (PolDom, charp_list, dim, A, lda, g, n);
         }
         catch (CharpolyFailed){}
         FFLAS::fassign (F, dim, dim, B, lda, A, lda);
@@ -98,7 +98,7 @@ int main (int argc, char** argv) {
         for (size_t i=0;i<iter;i++){
             chrono.start();
             try{
-                Protected::CharpolyArithProg (PolDom, charp_list, dim, A, lda, g, n);
+                Protected::CharpolyArithProgKrylovPrecond (PolDom, charp_list, dim, A, lda, g, n);
             }
             catch (CharpolyFailed){	i--;}
             chrono.stop();

--- a/autotune/tune_charpoly.sh
+++ b/autotune/tune_charpoly.sh
@@ -3,7 +3,7 @@ echo =================================================
 echo ========= FFLAS-FFPACK CharPoly Autotuning =========
 echo =================================================
 echo 
-(./arithprog 8 160 4 4 600 3 > arithprog-blocksize.h) 2>&1 | tee arithprog-blocksize-autotune.log
+(./arithprog 16 64 2 4 800 3 > arithprog-blocksize.h) 2>&1 | tee arithprog-blocksize-autotune.log
 
 (./charpoly-LUK-ArithProg > charpoly-LUK-ArithProg-threshold.h) 2>&1 | tee charpoly-LUK-ArithProg-autotune.log
 

--- a/benchmarks/benchmark-charpoly.C
+++ b/benchmarks/benchmark-charpoly.C
@@ -43,11 +43,12 @@ void run_with_field(int q, size_t bits, size_t n, size_t iter, std::string file,
     case 0: CT = FfpackAuto; break;
     case 1: CT = FfpackDanilevski; break;
     case 2: CT = FfpackLUK; break;
-    case 3: CT = FfpackArithProg; break;
-    case 4: CT = FfpackKG; break;
-    case 5: CT = FfpackKGFast; break;
-    case 6: CT = FfpackHybrid; break;
-    case 7: CT = FfpackKGFastG; break;
+    case 3: CT = FfpackArithProgKrylovPrecond; break;
+    case 4: CT = FfpackArithProg; break;
+    case 5: CT = FfpackKG; break;
+    case 6: CT = FfpackKGFast; break;
+    case 7: CT = FfpackHybrid; break;
+    case 8: CT = FfpackKGFastG; break;
     default: CT = FfpackAuto; break;
     }
     FFLAS::Timer chrono;

--- a/benchmarks/benchmark-charpoly.C
+++ b/benchmarks/benchmark-charpoly.C
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * ========LICENCE========
  */
+//#define __FFLASFFPACK_ARITHPROG_PROFILING
 
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
@@ -35,7 +36,7 @@ using namespace std;
 using namespace FFPACK;
 
 template<class Field>
-void run_with_field(int q, size_t bits, size_t n, size_t iter, std::string file, int variant){
+void run_with_field(int q, size_t bits, size_t n, size_t d, size_t iter, std::string file, int variant){
     Field F(q);
     typedef typename Field::Element Element;
     FFPACK::FFPACK_CHARPOLY_TAG CT;
@@ -67,7 +68,7 @@ void run_with_field(int q, size_t bits, size_t n, size_t iter, std::string file,
         typename Givaro::Poly1Dom<Field> R(F);
         chrono.clear();
         chrono.start();
-        FFPACK::CharPoly (R, cpol, n, A, n, CT);
+        FFPACK::CharPoly (R, cpol, n, A, n, CT, d);
         chrono.stop();
 
         time_charp+=chrono.usertime();
@@ -87,6 +88,7 @@ int main(int argc, char** argv) {
     int    q    = 131071;
     size_t bits = 10;
     size_t    n    = 1000;
+    size_t    d    = __FFLASFFPACK_ARITHPROG_THRESHOLD;
     std::string file = "";
     int variant = 0;
 
@@ -94,6 +96,7 @@ int main(int argc, char** argv) {
         { 'q', "-q Q", "Set the field characteristic (-1 for the ring ZZ).",  TYPE_INT , &q },
         { 'b', "-b B", "Set the bitsize of the random elements.",         TYPE_INT , &bits},
         { 'n', "-n N", "Set the dimension of the matrix.",               TYPE_INT , &n },
+        { 'd', "-d D", "Set the degree of the preconditionner (for ArithProg variant).",  TYPE_INT , &d },
         { 'i', "-i R", "Set number of repetitions.",                     TYPE_INT , &iter },
         { 'f', "-f FILE", "Set the input file (empty for random).",  TYPE_STR , &file },
         { 'a', "-a algorithm", "Set the algorithmic variant", TYPE_INT, &variant },
@@ -105,9 +108,9 @@ int main(int argc, char** argv) {
 
     if (q > 0){
         bits = Givaro::Integer(q).bitsize();
-        run_with_field<Givaro::ModularBalanced<double> >(q, bits, n , iter, file, variant);
+        run_with_field<Givaro::ModularBalanced<double> >(q, bits, n , d, iter, file, variant);
     } else
-        run_with_field<Givaro::ZRing<Givaro::Integer> > (q, bits, n , iter, file, variant);
+        run_with_field<Givaro::ZRing<Givaro::Integer> > (q, bits, n , d, iter, file, variant);
 
     FFLAS::writeCommandString(std::cout, as) << std::endl;
     return 0;

--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -1017,6 +1017,18 @@ namespace FFPACK { /* charpoly */
                            typename PolRing::Domain_t::RandIter& G,
                            const size_t block_size=__FFLASFFPACK_ARITHPROG_THRESHOLD);
 
+        template <class PolRing>
+        inline std::list<typename PolRing::Element>&
+        KrylovPreconditionner (const PolRing& PR, std::list<typename PolRing::Element>& frobeniusForm,
+                               const size_t N, typename PolRing::Domain_t::Element_ptr A, const size_t lda,
+                               typename PolRing::Domain_t::RandIter& g,
+                               const size_t degree);
+
+        template <class PolRing>
+        inline std::list<typename PolRing::Element>&
+        ArithProg (const PolRing& PR, std::list<typename PolRing::Element>& frobeniusForm,
+                   const size_t N, typename PolRing::Domain_t::Element_ptr A, const size_t lda,
+                   const size_t degree);
 
         template <class Field, class Polynomial>
         std::list<Polynomial>&

--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -78,11 +78,12 @@ namespace FFPACK  { /* tags */
         FfpackAuto = 0,
         FfpackDanilevski = 1,
         FfpackLUK = 2,
-        FfpackArithProg = 3,
-        FfpackKG = 4,
-        FfpackKGFast = 5,
-        FfpackHybrid = 6,
-        FfpackKGFastG = 7
+        FfpackArithProgKrylovPrecond = 3,
+        FfpackArithProg = 4,
+        FfpackKG = 5,
+        FfpackKGFast = 6,
+        FfpackHybrid = 7,
+        FfpackKGFastG = 8
     };
     /* \endcond */
     class CharpolyFailed{};
@@ -1008,22 +1009,14 @@ namespace FFPACK { /* charpoly */
         Danilevski (const Field& F, std::list<Polynomial>& charp,
                     const size_t N, typename Field::Element_ptr A, const size_t lda);
 
-        template <class PolRing>
-        std::list<typename PolRing::Element>&
-        CharpolyArithProg (const PolRing& R,
-                           std::list<typename PolRing::Element>& frobeniusForm,
-                           const size_t N,
-                           typename PolRing::Domain_t::Element_ptr A, const size_t lda,
-                           typename PolRing::Domain_t::RandIter& G,
-                           const size_t block_size=__FFLASFFPACK_ARITHPROG_THRESHOLD);
 
         template <class PolRing>
-        inline std::list<typename PolRing::Element>&
-        KrylovPreconditionner (const PolRing& PR, std::list<typename PolRing::Element>& frobeniusForm,
-                               const size_t N, typename PolRing::Domain_t::Element_ptr A, const size_t lda,
-                               typename PolRing::Domain_t::RandIter& g,
-                               const size_t degree);
-
+        inline void
+        RandomKrylovPrecond (const PolRing& PR, std::list<typename PolRing::Element>& completedFactors, const size_t N,
+                             typename PolRing::Domain_t::Element_ptr A, const size_t lda,
+                             size_t& Nb, typename PolRing::Domain_t::Element_ptr& B, size_t& ldb,
+                             typename PolRing::Domain_t::RandIter& g, const size_t degree=__FFLASFFPACK_ARITHPROG_THRESHOLD);
+        
         template <class PolRing>
         inline std::list<typename PolRing::Element>&
         ArithProg (const PolRing& PR, std::list<typename PolRing::Element>& frobeniusForm,

--- a/fflas-ffpack/ffpack/ffpack.h
+++ b/fflas-ffpack/ffpack/ffpack.h
@@ -929,11 +929,12 @@ namespace FFPACK { /* charpoly */
      * @param G a random iterator (required for the randomized variants LUKrylov and ArithProg)
      */
     template <class PolRing>
-    std::list<typename PolRing::Element>&
+    inline std::list<typename PolRing::Element>&
     CharPoly (const PolRing& R, std::list<typename PolRing::Element>& charp, const size_t N,
               typename PolRing::Domain_t::Element_ptr A, const size_t lda,
               typename PolRing::Domain_t::RandIter& G,
-              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto);
+              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto,
+              const size_t degree = __FFLASFFPACK_ARITHPROG_THRESHOLD);
 
     /**
      * @brief Compute the characteristic polynomial of the matrix A.
@@ -946,11 +947,12 @@ namespace FFPACK { /* charpoly */
      * @param G a random iterator (required for the randomized variants LUKrylov and ArithProg)
      */
     template <class PolRing>
-    typename PolRing::Element&
+    inline typename PolRing::Element&
     CharPoly (const PolRing& R, typename PolRing::Element& charp, const size_t N,
               typename PolRing::Domain_t::Element_ptr A, const size_t lda,
               typename PolRing::Domain_t::RandIter& G,
-              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto);
+              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto,
+              const size_t degree = __FFLASFFPACK_ARITHPROG_THRESHOLD);
 
     /**
      * @brief Compute the characteristic polynomial of the matrix A.
@@ -962,12 +964,13 @@ namespace FFPACK { /* charpoly */
      * @param CharpTag the algorithmic variant
      */
     template <class PolRing>
-    typename PolRing::Element&
+    inline typename PolRing::Element&
     CharPoly (const PolRing& R, typename PolRing::Element& charp, const size_t N,
               typename PolRing::Domain_t::Element_ptr A, const size_t lda,
-              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto){
+              const FFPACK_CHARPOLY_TAG CharpTag= FfpackAuto,
+              const size_t degree = __FFLASFFPACK_ARITHPROG_THRESHOLD){
         typename PolRing::Domain_t::RandIter G(R.getdomain());
-        return CharPoly (R, charp, N, A, lda, G, CharpTag);
+        return CharPoly (R, charp, N, A, lda, G, CharpTag, degree);
     }
 
 

--- a/fflas-ffpack/ffpack/ffpack_charpoly.inl
+++ b/fflas-ffpack/ffpack/ffpack_charpoly.inl
@@ -52,7 +52,8 @@ namespace FFPACK {
     std::list<typename PolRing::Element>&
     CharPoly (const PolRing& R, std::list<typename PolRing::Element>& charp, const size_t N,
               typename PolRing::Domain_t::Element_ptr A, const size_t lda,
-              typename PolRing::Domain_t::RandIter& G,const FFPACK_CHARPOLY_TAG CharpTag)
+              typename PolRing::Domain_t::RandIter& G,const FFPACK_CHARPOLY_TAG CharpTag,
+              const size_t degree)
     {
         // if (Protected::AreEqual<PolRing::Domain_t, Givaro::Modular<double> >::value ||
         //     Protected::AreEqual<PolRing::Domain_t, Givaro::ModularBalanced<double> >::value){
@@ -64,9 +65,9 @@ namespace FFPACK {
 
         FFPACK_CHARPOLY_TAG tag = CharpTag;
         if (tag == FfpackAuto){
-            if (N < __FFLASFFPACK_CHARPOLY_Danilevskii_LUKrylov_THRESHOLD)
+            if (N < degree)
                 tag = FfpackDanilevski;
-            else if (N< __FFLASFFPACK_CHARPOLY_LUKrylov_ArithProg_THRESHOLD)
+            else if (N < degree)
                 tag = FfpackLUK;
             else
                 tag = FfpackArithProgKrylovPrecond;
@@ -91,7 +92,6 @@ namespace FFPACK {
                 do{
                     cont=false;
                     try {
-                        size_t degree = __FFLASFFPACK_ARITHPROG_THRESHOLD; // @todo: value passed as a parameter
                             // Preconditionning by a random block Krylov matrix.
                             // Some invariant factors may be discovered in the process and are stored in charp.
                         typename Field::Element_ptr B;
@@ -148,7 +148,8 @@ namespace FFPACK {
     typename PolRing::Element&
     CharPoly (const PolRing& R, typename PolRing::Element& charp, const size_t N,
               typename PolRing::Domain_t::Element_ptr A, const size_t lda,
-              typename PolRing::Domain_t::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag){
+              typename PolRing::Domain_t::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag,
+              const size_t degree){
 
         typedef typename PolRing::Domain_t Field;
         typedef typename PolRing::Element Polynomial;
@@ -159,7 +160,7 @@ namespace FFPACK {
         Checker_charpoly<Field,Polynomial> checker(R.getdomain(),N,A,lda);
 
         std::list<Polynomial> factor_list;
-        CharPoly (R, factor_list, N, A, lda, G, CharpTag);
+        CharPoly (R, factor_list, N, A, lda, G, CharpTag, degree);
         typename std::list<Polynomial>::const_iterator it;
         it = factor_list.begin();
 

--- a/fflas-ffpack/ffpack/ffpack_charpoly_mp.inl
+++ b/fflas-ffpack/ffpack/ffpack_charpoly_mp.inl
@@ -40,7 +40,7 @@ namespace FFPACK {
                      typename FFPACK::RNSInteger<FFPACK::rns_double>::Element_ptr charp,
                      const size_t N,
                      typename FFPACK::RNSInteger<FFPACK::rns_double>::Element_ptr A, const size_t lda,
-                     Givaro::ZRing<Givaro::Integer>::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag){
+                     Givaro::ZRing<Givaro::Integer>::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag, size_t degree){
         //std::cerr<<"Using "<<F.size()<<" moduli";
         Givaro::Timer t;
         for(size_t i=0;i<F.size();i++){
@@ -50,7 +50,7 @@ namespace FFPACK {
             PolRing::Element cp(N+1);
             Field::RandIter Gp(F.rns()._field_rns[i]); //TODO set the seed from G's seed
             PolRing R(F.rns()._field_rns[i]);
-            FFPACK::CharPoly (R, cp, N, A._ptr+i*A._stride, lda, Gp, CharpTag);
+            FFPACK::CharPoly (R, cp, N, A._ptr+i*A._stride, lda, Gp, CharpTag, degree);
             FFLAS::fassign(Givaro::ZRing<double>(), N+1,  &(cp[0]),1, charp._ptr+i*charp._stride, 1);
             t.stop();
             //std::cerr<<"Iteration "<<i<<" --> "<<t.realtime()<<std::endl;
@@ -63,7 +63,7 @@ namespace FFPACK {
     CharPoly(const Givaro::Poly1Dom<Givaro::ZRing<Givaro::Integer> >& R,
              Givaro::Poly1Dom<Givaro::ZRing<Givaro::Integer> >::Element& charp,
              const size_t N,  Givaro::Integer * A, const size_t lda,
-             Givaro::ZRing<Givaro::Integer>::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag){
+             Givaro::ZRing<Givaro::Integer>::RandIter& G, const FFPACK_CHARPOLY_TAG CharpTag, size_t degree){
 
         const Givaro::ZRing<Givaro::Integer>& F = R.getdomain();
         size_t Abs = FFLAS::bitsize(F,N,N,A,lda);
@@ -83,7 +83,7 @@ namespace FFPACK {
         //std::cerr<<"...done"<<std::endl;
 
         //std::cerr<<"charpoly...";
-        CharPoly(Zrns, CPrns, N, Arns, N, G, CharpTag);
+        CharPoly(Zrns, CPrns, N, Arns, N, G, CharpTag, degree);
         //std::cerr<<"...done"<<std::endl;
 
         //std::cerr<<"fconvert...";

--- a/fflas-ffpack/ffpack/ffpack_frobenius.inl
+++ b/fflas-ffpack/ffpack/ffpack_frobenius.inl
@@ -104,7 +104,7 @@ namespace FFPACK { namespace Protected {
         for (size_t i = 0; i < noc; ++i)
             nzg.random (*(K + i*(degree*ldk+1)));
 
-        // Computing the bloc Krylov matrix [U AU .. A^(c-1) U]^T
+        // Computing the bloc Krylov matrix [u1 Au1 .. A^(c-1) u1 u2 Au2 ...]^T
         for (size_t i = 1; i<degree; ++i){
             fgemm( F, FFLAS::FflasNoTrans, FFLAS::FflasTrans,  noc, N, N,F.one,
                    K+(i-1)*ldk, degree*ldk, A, lda, F.zero, K+i*ldk, degree*ldk);
@@ -305,8 +305,10 @@ namespace FFPACK { namespace Protected {
         typedef typename PolRing::Element Polynomial;
         const Field& F = PR.getdomain();
 
+#ifdef __FFLASFFPACK_ARITHPROG_PROFILING
         Givaro::Timer tim;
         tim.start();
+#endif
 	size_t nb_full_blocks, Mk, Ma;
 	Mk = Ma = nb_full_blocks = (N-1)/degree +1;
 	typename Field::Element_ptr K, K3, Ac;
@@ -517,9 +519,10 @@ namespace FFPACK { namespace Protected {
             F.neg( Pl[j], *(K  + j*ldk));
         frobeniusForm.push_front(Pl);
         FFLAS::fflas_delete (Arp, Ac, K, dA, dK);
+#ifdef __FFLASFFPACK_ARITHPROG_PROFILING
         tim.stop();
         std::cerr<<"Arith Prog                 : "<<tim.usertime()<<std::endl;
-
+#endif
         return frobeniusForm;
     }
 

--- a/tests/test-charpoly.C
+++ b/tests/test-charpoly.C
@@ -63,7 +63,7 @@ bool launch_test(const Field & F, size_t n, typename Field::Element * A, size_t 
     case FfpackKGFast:  oss<<"KGFast variant"; break;
     case FfpackKGFastG: oss<<"KGFastG variant"; break;
     case FfpackHybrid: oss<<"Hybrid variant"; break;
-    case FfpackArithProg: oss<<"ArithProg variant"; break;
+    case FfpackArithProgKrylovPrecond: oss<<"Precond. ArithProg variant"; break;
     default: oss<<"LUKrylov variant"; break;
     }
     F.write(oss<<" over ");
@@ -105,6 +105,7 @@ bool launch_test(const Field & F, size_t n, typename Field::Element * A, size_t 
         F.subin (trace, B [i*(n+1)]);
     if (!F.areEqual(trace, charp[n-1])){
         std::cerr<<"FAILED: trace = "<<trace<<" P["<<n-1<<"] = "<<charp[n-1]<<std::endl;
+        std::cerr<<" P = "<<charp<<std::endl;
         FFLAS::fflas_delete (B);
         return false;
     }
@@ -119,6 +120,7 @@ bool launch_test(const Field & F, size_t n, typename Field::Element * A, size_t 
 
     if (!F.areEqual(det,charp[0])){
         std::cerr<<"FAILED: det = "<<det<<" P["<<0<<"] = "<<charp[0]<<std::endl;
+        std::cerr<<" P = "<<charp<<std::endl;
         return false;
     }
 
@@ -133,7 +135,7 @@ bool run_with_field(const Givaro::Integer p, uint64_t bits, size_t n, std::strin
     case 0: CT = FfpackAuto; break;
     case 1: CT = FfpackDanilevski; break;
     case 2: CT = FfpackLUK; break;
-    case 3: CT = FfpackArithProg; break;
+    case 3: CT = FfpackArithProgKrylovPrecond; break;
     case 4: CT = FfpackKG; break;
     case 5: CT = FfpackKGFast; break;
     case 6: CT = FfpackHybrid; break;
@@ -168,7 +170,7 @@ bool run_with_field(const Givaro::Integer p, uint64_t bits, size_t n, std::strin
         else{ // No variant specified, testing them all
             passed = passed && launch_test<Field>(*F, n, A, lda, iter, R, FfpackDanilevski);
             passed = passed && launch_test<Field>(*F, n, A, lda, iter, R, FfpackLUK);
-            passed = passed && launch_test<Field>(*F, n, A, lda, iter, R, FfpackArithProg);
+            passed = passed && launch_test<Field>(*F, n, A, lda, iter, R, FfpackArithProgKrylovPrecond);
             passed = passed && launch_test<Field>(*F, n, A, lda, iter, R, FfpackAuto);
             //passed = passed && launch_test<Field>(F, n, A, lda, iter, FfpackKG); // fails (variant only implemented for benchmarking
             //passed = passed && launch_test<Field>(*F, n, A, lda, iter, FfpackKGFast); // generic: does not work with any matrix


### PR DESCRIPTION
The Las-Vegas randomized algorithm Arithprog uses a block-Krylov preconditionner. The preconditioner is written in the same routine as the main algorithm.
This PR propose to:
 - separate the preconditioning phase from the main arithprog loop. In particular, it could be used by other algorithms (e.g. in LinBox).
 - expose the degree parameter of the preconditioner all the way up to the charpoly interface. This has become standard practice to allow benchmarking and autotuning, like for instance with PLUQ or fsytrf
 - tune up the construction of this preconditioner by avoiding some data movement.