### PR TITLE
enable a prologue setting openblas numthreads once for all

### DIFF
--- a/benchmarks/benchmark-charpoly.C
+++ b/benchmarks/benchmark-charpoly.C
@@ -20,6 +20,8 @@
  */
 //#define __FFLASFFPACK_ARITHPROG_PROFILING
 
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -83,6 +85,10 @@ void run_with_field(int q, size_t bits, size_t n, size_t d, size_t iter, std::st
 }
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 1;
     int    q    = 131071;

--- a/benchmarks/benchmark-echelon.C
+++ b/benchmarks/benchmark-echelon.C
@@ -18,6 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * ========LICENCE========
  */
+
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include "fflas-ffpack/config-blas.h"
@@ -204,6 +209,10 @@ void verification_PLUQ(const Field & F, typename Field::Element * B, typename Fi
 
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3 ;
     int q = 131071 ;

--- a/benchmarks/benchmark-fadd-lvl2.C
+++ b/benchmarks/benchmark-fadd-lvl2.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -33,6 +37,10 @@ using namespace std;
 using namespace FFLAS;
 using namespace FFPACK;
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter      = 3;
     int    q         = 131071;

--- a/benchmarks/benchmark-fdot.C
+++ b/benchmarks/benchmark-fdot.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -97,6 +101,10 @@ typename Field::Element run_with_field(int q, size_t iter, size_t N, const size_
 }
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 20; // to get nonzero time
     size_t N    = 5000;

--- a/benchmarks/benchmark-fgemm-mp.C
+++ b/benchmarks/benchmark-fgemm-mp.C
@@ -24,6 +24,10 @@
  *.
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 
 #if not defined(MG_DEFAULT)
 #define MG_DEFAULT MG_ACTIVE
@@ -225,6 +229,11 @@ int tmain(){
 }
 
 int main(int argc, char** argv){
+  
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
+
     FFLAS::parseArguments(argc,argv,as);
 
     int r1 = tmain<Givaro::Integer>();

--- a/benchmarks/benchmark-fgemm-rns.C
+++ b/benchmarks/benchmark-fgemm-rns.C
@@ -19,6 +19,10 @@
  */
 
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas/fflas.h"
 
 #include <iostream>
@@ -109,6 +113,11 @@ bench_do_it (const Field ZZ, const size_t m, const size_t n, const size_t k,
 int
 main(int argc, char *argv[])
 {
+ 
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
+
     size_t pbits = 20;
     size_t r = 8;
     size_t m = 1000;

--- a/benchmarks/benchmark-fgemv-mp.C
+++ b/benchmarks/benchmark-fgemv-mp.C
@@ -24,6 +24,10 @@
  *.
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #if not defined(MG_DEFAULT)
 #define MG_DEFAULT MG_ACTIVE
 #endif
@@ -175,6 +179,11 @@ int tmain(){
 
 
 int main(int argc, char** argv){
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
+
     FFLAS::parseArguments(argc,argv,as);
 
     int r1 = tmain<Givaro::Integer>();

--- a/benchmarks/benchmark-fgemv.C
+++ b/benchmarks/benchmark-fgemv.C
@@ -20,6 +20,10 @@
 
 //#include "goto-def.h"
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular-balanced.h>
@@ -219,8 +223,12 @@ void benchmark_with_field(const Givaro::Integer& q, int p,  size_t m, size_t k,
 }
 
 int main(int argc, char** argv) {
+ 
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
-  int p=0;
+    int p=0;
 
   size_t iters = 3;
   Givaro::Integer q = 131071;

--- a/benchmarks/benchmark-fgesv.C
+++ b/benchmarks/benchmark-fgesv.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -31,6 +35,10 @@
 using namespace std;
 
 int main(int argc, char** argv) {
+ 
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3;
     int    q    = 131071;

--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -32,6 +36,10 @@ using namespace std;
 using namespace FFLAS;
 using namespace FFPACK;
 int main(int argc, char** argv) {
+
+ #ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3;
     int    q    = 131071;

--- a/benchmarks/benchmark-fsytrf.C
+++ b/benchmarks/benchmark-fsytrf.C
@@ -23,6 +23,8 @@
 #undef __FFPACK_FSYTRF_BC_RL
 #define __FFPACK_FSYTRF_BC_CROUT
 
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -36,6 +38,10 @@
 using namespace std;
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3;
     int    q    = 131071;

--- a/benchmarks/benchmark-ftrsm-mp.C
+++ b/benchmarks/benchmark-ftrsm-mp.C
@@ -23,6 +23,11 @@
  * ========LICENCE========
  *.
  */
+
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <vector>
@@ -35,6 +40,11 @@ using namespace std;
 #include "givaro/modular-integer.h"
 
 int main(int argc, char** argv){
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
+
     srand((int)time(NULL));
     srand48(time(NULL));
 

--- a/benchmarks/benchmark-ftrsm.C
+++ b/benchmarks/benchmark-ftrsm.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -31,6 +35,10 @@
 using namespace std;
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3;
     int    q    = 1009;

--- a/benchmarks/benchmark-ftrsv.C
+++ b/benchmarks/benchmark-ftrsv.C
@@ -19,6 +19,10 @@
  * ========LICENCE========
  */
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
@@ -31,6 +35,10 @@ using namespace std;
 using namespace FFLAS;
 
 int main(int argc, char** argv) {
+
+ #ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 10;
     int    q    = 131071;

--- a/benchmarks/benchmark-ftrtri.C
+++ b/benchmarks/benchmark-ftrtri.C
@@ -28,10 +28,18 @@
 #include "fflas-ffpack/utils/fflas_io.h"
 #include "fflas-ffpack/utils/args-parser.h"
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
 
 using namespace std;
 
 int main(int argc, char** argv) {
+
+ 
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3;
     int    q    = 131071;

--- a/benchmarks/benchmark-pluq.C
+++ b/benchmarks/benchmark-pluq.C
@@ -43,6 +43,10 @@
 #define MONOTONIC_APPLYP
 #endif
 
+// declare that the call to openblas_set_numthread will be made here, hence don't do it
+// everywhere in the call stack
+#define __FFLASFFPACK_OPENBLAS_NT_ALREADY_SET 1
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <givaro/modular.h>
 #include <givaro/givranditer.h>
@@ -156,6 +160,10 @@ void Rec_Initialize(Field &F, Field::Element * C, size_t m, size_t n, size_t ldc
 }
 
 int main(int argc, char** argv) {
+
+#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+    openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
+#endif
 
     size_t iter = 3 ;
     bool slab=false;

--- a/fflas-ffpack/fflas/fflas_fassign.inl
+++ b/fflas-ffpack/fflas/fflas_fassign.inl
@@ -71,7 +71,7 @@ namespace FFLAS {
              float * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_scopy((int)N,Y,(int)incY,X,(int)incX);
@@ -86,7 +86,7 @@ namespace FFLAS {
              float * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_scopy((int)N,Y,(int)incY,X,(int)incX);
@@ -101,7 +101,7 @@ namespace FFLAS {
              float * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_scopy((int)N,Y,(int)incY,X,(int)incX);
@@ -116,7 +116,7 @@ namespace FFLAS {
              double * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dcopy((int)N,Y,(int)incY,X,(int)incX);
@@ -131,7 +131,7 @@ namespace FFLAS {
              double * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dcopy((int)N,Y,(int)incY,X,(int)incX);
@@ -146,7 +146,7 @@ namespace FFLAS {
              double * X, const size_t incX)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dcopy((int)N,Y,(int)incY,X,(int)incX);

--- a/fflas-ffpack/fflas/fflas_faxpy.inl
+++ b/fflas-ffpack/fflas/fflas_faxpy.inl
@@ -64,7 +64,7 @@ namespace FFLAS {
            Givaro::DoubleDomain::Element_ptr y, const size_t incy )
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_daxpy( (int)N, a, x, (int)incx, y, (int)incy);
@@ -78,7 +78,7 @@ namespace FFLAS {
            Givaro::FloatDomain::Element_ptr y, const size_t incy )
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_saxpy( (int)N, a, x, (int)incx, y, (int)incy);

--- a/fflas-ffpack/fflas/fflas_fdot.inl
+++ b/fflas-ffpack/fflas/fflas_fdot.inl
@@ -94,7 +94,7 @@ namespace FFLAS {
           ModeCategories::DefaultTag& MT)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         return cblas_ddot( (int)N, x, (int)incx, y, (int)incy );
@@ -108,7 +108,7 @@ namespace FFLAS {
           ModeCategories::DefaultTag& MT)
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         return cblas_sdot( (int)N, x, (int)incx, y, (int)incy );

--- a/fflas-ffpack/fflas/fflas_fgemm.inl
+++ b/fflas-ffpack/fflas/fflas_fgemm.inl
@@ -470,7 +470,7 @@ namespace FFLAS {
 
         // Call to the blas Multiplication
         FFLASFFPACK_check(n);
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dgemm (CblasRowMajor, (CBLAS_TRANSPOSE)ta,

--- a/fflas-ffpack/fflas/fflas_fgemm/fgemm_classical.inl
+++ b/fflas-ffpack/fflas/fflas_fgemm/fgemm_classical.inl
@@ -249,7 +249,7 @@ namespace FFLAS {
         FFLASFFPACK_check(lda);
         FFLASFFPACK_check(ldb);
         FFLASFFPACK_check(ldc);
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dgemm (CblasRowMajor, (CBLAS_TRANSPOSE) ta, (CBLAS_TRANSPOSE) tb,
@@ -272,7 +272,7 @@ namespace FFLAS {
         FFLASFFPACK_check(ldb);
         FFLASFFPACK_check(ldc);
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_sgemm (CblasRowMajor, (CBLAS_TRANSPOSE) ta, (CBLAS_TRANSPOSE) tb,

--- a/fflas-ffpack/fflas/fflas_fgemv.inl
+++ b/fflas-ffpack/fflas/fflas_fgemv.inl
@@ -416,7 +416,7 @@ namespace FFLAS{
     {
         FFLASFFPACK_check(lda);
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dgemv (CblasRowMajor, (CBLAS_TRANSPOSE) ta,
@@ -454,7 +454,7 @@ namespace FFLAS{
     {
         FFLASFFPACK_check(lda);
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_sgemv (CblasRowMajor, (CBLAS_TRANSPOSE) ta,

--- a/fflas-ffpack/fflas/fflas_fger.inl
+++ b/fflas-ffpack/fflas/fflas_fger.inl
@@ -176,7 +176,7 @@ namespace FFLAS{
     {
         if (F.isZero(alpha)) { return ; }
         FFLASFFPACK_check(lda);
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dger( CblasRowMajor, (int)M, (int)N, alpha, x, (int)incx, y, (int)incy, A, (int)lda );
@@ -207,7 +207,7 @@ namespace FFLAS{
         if (F.isZero(alpha)) { return ; }
 
         FFLASFFPACK_check(lda);
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_sger( CblasRowMajor, (int)M, (int)N, alpha, x, (int)incx, y, (int)incy, A, (int)lda );

--- a/fflas-ffpack/fflas/fflas_fscal.inl
+++ b/fflas-ffpack/fflas/fflas_fscal.inl
@@ -292,7 +292,7 @@ namespace FFLAS {
            Givaro::DoubleDomain::ConstElement_ptr x, const size_t incx,
            Givaro::DoubleDomain::Element_ptr y, const size_t incy )
     {
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dcopy( (int)N, x, (int)incy, y, (int)incy);
@@ -306,7 +306,7 @@ namespace FFLAS {
            Givaro::FloatDomain::ConstElement_ptr x, const size_t incx,
            Givaro::FloatDomain::Element_ptr y, const size_t incy )
     {
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_scopy( (int)N, x, (int)incy, y, (int)incy);
@@ -320,7 +320,7 @@ namespace FFLAS {
              Givaro::DoubleDomain::Element_ptr y, const size_t incy )
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_dscal( (int)N, a, y, (int)incy);
@@ -333,7 +333,7 @@ namespace FFLAS {
              Givaro::FloatDomain::Element_ptr y, const size_t incy )
     {
 
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         cblas_sscal( (int)N, a, y, (int)incy);

--- a/fflas-ffpack/fflas/fflas_ftrmm_src.inl
+++ b/fflas-ffpack/fflas/fflas_ftrmm_src.inl
@@ -189,7 +189,7 @@ public:
                   typename Field::ConstElement_ptr A, const size_t lda,
                   typename Field::Element_ptr B, const size_t ldb)
     {
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
         Mjoin(cblas_,Mjoin(__FFLAS__BLAS_PREFIX,trmm))
@@ -209,7 +209,7 @@ public:
                   const typename Field::Element beta,
                   typename Field::Element_ptr C, const size_t ldc)
     {
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
         openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
 

--- a/fflas-ffpack/fflas/fflas_ftrsm_src.inl
+++ b/fflas-ffpack/fflas/fflas_ftrsm_src.inl
@@ -273,7 +273,7 @@ public:
             }
 #endif // __FFLAS__UNIT
 #ifndef __FFLAS_MULTIPRECISION
-#ifdef __FFLASFFPACK_OPENBLAS_NUM_THREADS
+#if defined(__FFLASFFPACK_OPENBLAS_NUM_THREADS) and not defined (__FFLASFFPACK_OPENBLAS_NT_ALREADY_SET)
             openblas_set_num_threads(__FFLASFFPACK_OPENBLAS_NUM_THREADS);
 #endif
             Mjoin(cblas_,Mjoin(__FFLAS__BLAS_PREFIX,trsm))


### PR DESCRIPTION
Fixes #253 .
We may move slowly toward the introduction of a prologue function `fflas-setup()` which will take care of initializing some global variables, and setting openblas numthreads once for all.
For the moment this PR does by 
 - setting manually the openblas numthreads in each benchmark file
 - adding a macro to notify that it has been done, so that it will not be called before each BLAS call.