### PR TITLE
queryCacheSizes: add Hygon Dhyana support to fix cache size bug

### DIFF
--- a/fflas-ffpack/utils/fflas_memory.h
+++ b/fflas-ffpack/utils/fflas_memory.h
@@ -344,7 +344,8 @@ namespace FFLAS{
         int max_std_funcs = abcd[1];
         if(cpuid_is_vendor(abcd,"GenuineIntel"))
             queryCacheSizes_intel(l1,l2,l3,max_std_funcs);
-        else if(cpuid_is_vendor(abcd,"AuthenticAMD") || cpuid_is_vendor(abcd,"AMDisbetter!"))
+        else if(cpuid_is_vendor(abcd,"AuthenticAMD") || cpuid_is_vendor(abcd,"AMDisbetter!")
+          || cpuid_is_vendor(abcd, "HygonGenuine"))
             queryCacheSizes_amd(l1,l2,l3);
         else
             // by default let's use Intel's API


### PR DESCRIPTION
Add Hygon Dhyana CPU Vendor ID("HygonGenuine") checking to enable cache size calculation, as Hygon Dhyana(Family 18h) share similiar arch with AMD Family 17h.