### PR TITLE
Adding public attributes to Simd structs

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -41,6 +41,9 @@
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include "fflas-ffpack/utils/debug.h"
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 #if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #define INLINE __attribute__((always_inline)) inline
 #else
@@ -317,6 +320,14 @@ struct NoSimd {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 1;
+
+    /*
+     *  alignement for scalar_t pointer to be loaded in a vect_t
+     * [ available to have the same interface as SimdXXX classes ]
+     */
+    static const constexpr size_t alignment = static_cast<size_t>(Alignment::Normal);
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /* Name of the NoSimd struct */
     static inline const std::string type_string () { return "NoSimd"; }

--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -43,6 +43,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 #if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #define INLINE __attribute__((always_inline)) inline
@@ -328,6 +329,10 @@ struct NoSimd {
     static const constexpr size_t alignment = static_cast<size_t>(Alignment::Normal);
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, T>;
 
     /* Name of the NoSimd struct */
     static inline const std::string type_string () { return "NoSimd"; }

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -28,6 +28,9 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_double_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_double_INL
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd128 specialized for double
  */
@@ -53,6 +56,8 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 16;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -30,6 +30,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd128 specialized for double
@@ -58,6 +59,10 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
     static const constexpr size_t alignment = 16;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -28,6 +28,9 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_float_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_float_INL
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd128 specialized for float
  */
@@ -53,6 +56,8 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 16;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -30,6 +30,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd128 specialized for float
@@ -58,6 +59,10 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
     static const constexpr size_t alignment = 16;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -33,6 +33,9 @@
 #error "You need SSE instructions to perform 128 bits operations on int16"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd128 specialized for int16_t
  */
@@ -57,6 +60,8 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 16;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -424,6 +429,9 @@ template <> struct Simd128_impl<true, true, false, 2> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint16_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -35,6 +35,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd128 specialized for int16_t
@@ -62,6 +63,10 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
     static const constexpr size_t alignment = 16;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -432,6 +437,10 @@ template <> struct Simd128_impl<true, true, false, 2> : public Simd128_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -39,6 +39,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd128 specialized for int32_t
@@ -66,6 +67,10 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
     static const constexpr size_t alignment = 16;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -466,6 +471,10 @@ template <> struct Simd128_impl<true, true, false, 4> : public Simd128_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -37,6 +37,9 @@
 #include "fflas-ffpack/fflas/fflas_simd/simd128_int64.inl"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd128 specialized for int32_t
  */
@@ -61,6 +64,8 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 16;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -458,6 +463,9 @@ template <> struct Simd128_impl<true, true, false, 4> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -34,6 +34,9 @@
 #error "You need SSE instructions to perform 128 bits operations on int64"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd128 specialized for int64_t
  */
@@ -58,6 +61,8 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 16;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -470,6 +475,9 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -36,6 +36,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd128 specialized for int64_t
@@ -63,6 +64,10 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
     static const constexpr size_t alignment = 16;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -478,6 +483,10 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Converter from vect_t to a tab.

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -32,6 +32,9 @@
 #error "You need AVX instructions to perform 256bits operations on double"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for double
  */
@@ -55,6 +58,8 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
      *	alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 32;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -34,6 +34,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for double
@@ -60,6 +61,10 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
     static const constexpr size_t alignment = 32;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -28,6 +28,9 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd256_float_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd256_float_INL
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for float
  */
@@ -52,6 +55,8 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
      *	alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 32;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -30,6 +30,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for float
@@ -57,6 +58,10 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
     static const constexpr size_t alignment = 32;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -33,6 +33,9 @@
 #error "You need AVX2 instructions to perform 256bits operations on int16_t"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for int16_t
  */
@@ -67,6 +70,8 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 32;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -536,6 +541,9 @@ template <> struct Simd256_impl<true, true, false, 2> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint16_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -35,6 +35,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for int16_t
@@ -72,6 +73,10 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
     static const constexpr size_t alignment = 32;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -544,6 +549,10 @@ template <> struct Simd256_impl<true, true, false, 2> : public Simd256_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -37,6 +37,9 @@
 #include "fflas-ffpack/fflas/fflas_simd/simd256_int64.inl"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for int32_t
  */
@@ -71,6 +74,8 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 32;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -548,6 +553,9 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -39,6 +39,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for int32_t
@@ -76,6 +77,10 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
     static const constexpr size_t alignment = 32;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -556,6 +561,10 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -36,6 +36,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for int64_t
@@ -73,6 +74,10 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
     static const constexpr size_t alignment = 32;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -517,6 +522,10 @@ template <> struct Simd256_impl<true, true, false, 8> : public Simd256_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -34,6 +34,9 @@
 #error "You need AVX2 instructions to perform 256bits operations on int64_t"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for int64_t
  */
@@ -68,6 +71,8 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 32;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -509,6 +514,9 @@ template <> struct Simd256_impl<true, true, false, 8> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -31,6 +31,9 @@
 #error "You need AVX512 instructions to perform 512bits operations on double"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd512 specialized for double
  */
@@ -54,6 +57,8 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      *	alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 64;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -33,6 +33,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd512 specialized for double
@@ -59,6 +60,10 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
     static const constexpr size_t alignment = 64;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -29,6 +29,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd512 specialized for float
@@ -56,6 +57,10 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static const constexpr size_t alignment = 64;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -27,6 +27,9 @@
 #ifndef __FFLASFFPACK_simd512_float_INL
 #define __FFLASFFPACK_simd512_float_INL
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd512 specialized for float
  */
@@ -51,6 +54,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      *	alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 64;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -35,6 +35,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd256 specialized for int32_t
@@ -72,6 +73,10 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd512i_base {
     static const constexpr size_t alignment = 64;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -548,6 +553,10 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -33,6 +33,9 @@
 
 #include "fflas-ffpack/fflas/fflas_simd/simd512_int64.inl"
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd256 specialized for int32_t
  */
@@ -67,6 +70,8 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd512i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 64;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -540,6 +545,9 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -32,6 +32,9 @@
 #error "You need AVX512 instructions to perform 512bits operations on int64_t"
 #endif
 
+#include "fflas-ffpack/utils/align-allocator.h"
+#include <vector>
+
 /*
  * Simd512 specialized for int64_t
  */
@@ -66,6 +69,8 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
      *  alignement required by scalar_t pointer to be loaded in a vect_t
      */
     static const constexpr size_t alignment = 64;
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -553,6 +558,9 @@ template <> struct Simd512_impl<true, true, false, 8> : public Simd512_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
+    using aligned_vector = std::vector<scalar_t, aligned_allocator>;
 
     /*
      * Simd128 for scalar_t, to deal half_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -34,6 +34,7 @@
 
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
+#include <type_traits>
 
 /*
  * Simd512 specialized for int64_t
@@ -71,6 +72,10 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     static const constexpr size_t alignment = 64;
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Check if the pointer p is a multiple of alignemnt
@@ -561,6 +566,10 @@ template <> struct Simd512_impl<true, true, false, 8> : public Simd512_impl<true
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;
+
+    /* To check compatibility with Modular struct */
+    template <class Field>
+    using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
     /*
      * Simd128 for scalar_t, to deal half_t


### PR DESCRIPTION
As linbox-team/givaro#118, this is a cosmetic PR.

1. The first commit 1adc3d2 offers a solution to the following problem: how to defined a vector container that is properly aligned for a given simd struct. It allows to write code like
```cpp
template <class simd>
class Example
{
  /* v will be a std::vector of simd::scalar_t that is aligned so it can be used with simd methods */
  typename simd:aligned_vector v;
}
```

2. The second commit 9451115 makes it easier to test if a Modular and Simd have the same base type
Before we would write 
```cpp
template <class M, class S, typename std::enable_if<std::is_same<typename M::Element, typename S::scalar_t>::value>::type>
...
```
With this commit we could write
```cpp
template <class M, class S, typename std::enable_if<S::template is_same_element<M>::value>::type>
```
which is, in my opinion, a little bit easier to write and read.