### PR TITLE
make autotune should fail when some run segfaults

### DIFF
--- a/autotune/tune_charpoly.sh
+++ b/autotune/tune_charpoly.sh
@@ -1,10 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK CharPoly Autotuning =========
 echo =================================================
 echo 
 (./arithprog 16 64 2 4 800 3 > arithprog-blocksize.h) 2>&1 | tee arithprog-blocksize-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi
 
 (./charpoly-LUK-ArithProg > charpoly-LUK-ArithProg-threshold.h) 2>&1 | tee charpoly-LUK-ArithProg-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi
 
 (./charpoly-Danilevskii-LUK > charpoly-Danilevskii-LUK-threshold.h) 2>&1 | tee charpoly-Danilevskii-LUK-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi

--- a/autotune/tune_fgemm.sh
+++ b/autotune/tune_fgemm.sh
@@ -1,16 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK fgemm Autotuning =========
 echo =================================================
 echo 
 echo "== Tuning fgemm over Modular<double> =="
 (./winograd-modular-double > fgemm-thresholds.h) 2>&1 | tee fgemm-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi
 echo 
 echo "== Tuning fgemm over Modular<float> =="
 (./winograd-modular-float >>  fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi
 echo 
 echo "== Tuning fgemm over ModularBalanced<double> =="
 (./winograd-modularbalanced-double >> fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi
 echo 
 echo "== Tuning fgemm over ModularBalanced<float> =="
 (./winograd-modularbalanced-float >>  fgemm-thresholds.h) 2>&1 | tee -a fgemm-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi

--- a/autotune/tune_fsyrk.sh
+++ b/autotune/tune_fsyrk.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK fsyrk Autotuning =========
 echo =================================================
 echo 
 (./fsyrk > fsyrk-threshold.h) 2>&1 | tee fsyrk-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi

--- a/autotune/tune_fsytrf.sh
+++ b/autotune/tune_fsytrf.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK fsytrf Autotuning ========
 echo =================================================
 echo 
 (./fsytrf > fsytrf-threshold.h) 2>&1 | tee fsytrf-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi

--- a/autotune/tune_ftrtri.sh
+++ b/autotune/tune_ftrtri.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK ftrtri Autotuning ========
 echo =================================================
 echo 
 (./ftrtri > ftrtri-threshold.h) 2>&1 | tee ftrtri-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi

--- a/autotune/tune_pluq.sh
+++ b/autotune/tune_pluq.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 echo =================================================
 echo ========= FFLAS-FFPACK PLUQ Autotuning ==========
 echo =================================================
 echo 
 (./pluq > pluq-threshold.h) 2>&1 | tee pluq-autotune.log
+val=${PIPESTATUS[0]}; if test ${val} -ne 0 ; then exit ${val}; fi


### PR DESCRIPTION
So far, when a run in autotune did segfault, then no error signal was forwarded to the make command and jenkins silently kept running the script.
This PR fixes the issue. The main point is to be able to get the return value of the left operand of a pipe.
Needs to introduce some bashism.