### PR TITLE
seed/size order reverted

### DIFF
--- a/fflas-ffpack/field/rns-double.h
+++ b/fflas-ffpack/field/rns-double.h
@@ -424,10 +424,10 @@ namespace FFPACK {
         const RNS& _domain;
 
     public:
-        rnsRandIter(const RNS& R, uint64_t seed=0, size_t bitSize=0)
+        rnsRandIter(const RNS& R, uint64_t seed=0)
         : _domain(R) {
             for(const auto& F : R._field_rns)
-                _RNS_rand.emplace_back(F,seed,bitSize);
+                _RNS_rand.emplace_back(F,seed);
         }
 
         /** RNS ring Element random assignement.

--- a/fflas-ffpack/field/rns-double.h
+++ b/fflas-ffpack/field/rns-double.h
@@ -424,10 +424,10 @@ namespace FFPACK {
         const RNS& _domain;
 
     public:
-        rnsRandIter(const RNS& R, size_t size=0, uint64_t seed=0)
+        rnsRandIter(const RNS& R, uint64_t seed=0, size_t bitSize=0)
         : _domain(R) {
             for(const auto& F : R._field_rns)
-                _RNS_rand.emplace_back(F,size,seed);
+                _RNS_rand.emplace_back(F,seed,bitSize);
         }
 
         /** RNS ring Element random assignement.

--- a/fflas-ffpack/field/rns-integer-mod.h
+++ b/fflas-ffpack/field/rns-integer-mod.h
@@ -75,7 +75,7 @@ namespace FFPACK {
             const RNSIntegerMod<RNS> & _F;
             uint64_t _seed;
         public:
-            RandIter(const RNSIntegerMod<RNS> &F, size_t size=0, uint64_t seed=0) :rnsRandIter<RNS>(*F._rns,size,seed), _F(F), _seed(seed) {}
+            RandIter(const RNSIntegerMod<RNS> &F, uint64_t seed=0, size_t bitSize=0) :rnsRandIter<RNS>(*F._rns,seed,bitSize), _F(F), _seed(seed) {}
 
             typename RNS::Element& random(typename RNS::Element& elt) const {
                 integer::seeding(_seed);

--- a/fflas-ffpack/field/rns-integer-mod.h
+++ b/fflas-ffpack/field/rns-integer-mod.h
@@ -75,7 +75,7 @@ namespace FFPACK {
             const RNSIntegerMod<RNS> & _F;
             uint64_t _seed;
         public:
-            RandIter(const RNSIntegerMod<RNS> &F, uint64_t seed=0, size_t bitSize=0) :rnsRandIter<RNS>(*F._rns,seed,bitSize), _F(F), _seed(seed) {}
+            RandIter(const RNSIntegerMod<RNS> &F, uint64_t seed=0) :rnsRandIter<RNS>(*F._rns,seed), _F(F), _seed(seed) {}
 
             typename RNS::Element& random(typename RNS::Element& elt) const {
                 integer::seeding(_seed);

--- a/fflas-ffpack/field/rns-integer.h
+++ b/fflas-ffpack/field/rns-integer.h
@@ -52,7 +52,7 @@ namespace FFPACK {
 
         class RandIter : public rnsRandIter<RNS> {
         public:
-            RandIter(const RNSInteger<RNS> &F, uint64_t seed=0, size_t bitSize=0) : rnsRandIter<RNS>(*F._rns,seed,bitSize) {}
+            RandIter(const RNSInteger<RNS> &F, uint64_t seed=0) : rnsRandIter<RNS>(*F._rns,seed) {}
         };
 
 

--- a/fflas-ffpack/field/rns-integer.h
+++ b/fflas-ffpack/field/rns-integer.h
@@ -52,7 +52,7 @@ namespace FFPACK {
 
         class RandIter : public rnsRandIter<RNS> {
         public:
-            RandIter(const RNSInteger<RNS> &F, size_t size=0, uint64_t seed=0) : rnsRandIter<RNS>(*F._rns,size,seed) {}
+            RandIter(const RNSInteger<RNS> &F, uint64_t seed=0, size_t bitSize=0) : rnsRandIter<RNS>(*F._rns,seed,bitSize) {}
         };
 
 


### PR DESCRIPTION
Maybe emplace_back should not use bitSize ?
Or shift ?