### PR TITLE
Plug memory leaks.

### DIFF
--- a/fflas-ffpack/ffpack/ffpack_charpoly.inl
+++ b/fflas-ffpack/ffpack/ffpack_charpoly.inl
@@ -90,11 +90,11 @@ namespace FFPACK {
                 if (p < (uint64_t)N)	// Heuristic condition (the pessimistic theoretical one being p<2n^2).
                     return CharPoly(R, charp, N, A, lda, G, FfpackLUK);
                 do{
+                    typename Field::Element_ptr B = nullptr;
                     cont=false;
                     try {
                             // Preconditionning by a random block Krylov matrix.
                             // Some invariant factors may be discovered in the process and are stored in charp.
-                        typename Field::Element_ptr B;
                         size_t ldb, Nb;
                         Protected::RandomKrylovPrecond (R, charp, N, A, lda, Nb, B, ldb, G, degree);
                             // Calling the main algorithm on the preconditionned part
@@ -102,6 +102,8 @@ namespace FFPACK {
                         FFLAS::fflas_delete(B);
                     }
                     catch (CharpolyFailed){
+                        if (B != nullptr)
+                            FFLAS::fflas_delete(B);
                         charp.clear();
                         if (++attempts < 2)
                             cont = true;

--- a/fflas-ffpack/ffpack/ffpack_frobenius.inl
+++ b/fflas-ffpack/ffpack/ffpack_frobenius.inl
@@ -278,8 +278,7 @@ namespace FFPACK { namespace Protected {
             std::cerr<<"  left-over                : "<<timrest.usertime()<<std::endl;
 #endif
 
-        FFLAS::fflas_delete( Pk);
-        FFLAS::fflas_delete( Qk);
+        FFLAS::fflas_delete (K, K3, Pk, Qk);
         for (size_t i=0; i<Mk; ++i)
             dA[i] = dK[i];
         bk_idx = 0;
@@ -290,7 +289,7 @@ namespace FFPACK { namespace Protected {
 
         for (size_t j=0; j<Ma; ++j)
             FFLAS::fassign(F, Ncurr, K4+j*ldk, 1, B+j, ldb);
-        FFLAS::fflas_delete (K4);
+        FFLAS::fflas_delete (dA, dK, K4);
 
     }
 
@@ -338,6 +337,7 @@ namespace FFPACK { namespace Protected {
             // Main loop of the arithmetic progession
         while ((nb_full_blocks >= 1) && (Mk > 1)) {
             size_t block_idx, it_idx, rp_val;
+            FFLAS::fflas_delete (K);
             K = FFLAS::fflas_new (F, Ncurr, Ma);
             K3 = FFLAS::fflas_new (F, Ncurr, Ma);
             ldk = Ma;
@@ -507,9 +507,6 @@ namespace FFPACK { namespace Protected {
 
             deg++;
             FFLAS::fflas_delete (K3, rp);
-            if ((nb_full_blocks > 0) && (Mk > 1))
-                FFLAS::fflas_delete(K);
-
         }
 
         // Recovery of the first invariant factor

--- a/fflas-ffpack/ffpack/ffpack_fsytrf.inl
+++ b/fflas-ffpack/ffpack/ffpack_fsytrf.inl
@@ -462,6 +462,7 @@ namespace FFPACK {
         FFLAS::fflas_delete( P1);
         FFLAS::fflas_delete( P2);
         FFLAS::fflas_delete( P3);
+        FFLAS::fflas_delete( Q2);
         for (size_t i=N1; i<N; ++i)
             MathP[i] += N1;
 
@@ -486,6 +487,7 @@ namespace FFPACK {
         }
         FFLAS::fassign(Fi, R1, R3, tmpV1+N1-R1+R2, dim, A+R1+2*R2, lda);
         FFLAS::fassign(Fi, R1, N1-R1-R2, tmpV1+R2, dim, A+R1+2*R2+R3, lda);
+        FFLAS::fflas_delete(tmpV1);
 
         if (R2){
             // Interleaving L2^T, U2 and H1 into
@@ -563,7 +565,7 @@ namespace FFPACK {
         std::copy(tmpi, tmpi+N1-R1-R2, MP1);
 
         MathPerm2LAPACKPerm (P, MathP, N);
-        FFLAS::fflas_delete( MathP);
+        FFLAS::fflas_delete( MathP, tmpP );
 
         // Reporting the 2x2 blocks in P
         for (size_t i=0; i<R1+2*R2+R3; i++){

--- a/fflas-ffpack/ffpack/ffpack_invert.inl
+++ b/fflas-ffpack/ffpack/ffpack_invert.inl
@@ -49,8 +49,8 @@ namespace FFPACK {
         size_t R =  ReducedRowEchelonForm (F, M, M, A, lda, P, Q, true, FfpackGaussJordanTile);
         nullity = (int)(M - R);
         applyP (F, FFLAS::FflasRight, FFLAS::FflasNoTrans, M, 0, (int)R, A, lda, P);
-        delete [] P;
-        delete [] Q;
+        FFLAS::fflas_delete(P);
+        FFLAS::fflas_delete(Q);
 
         checker.check(A,nullity);
         return A;

--- a/tests/test-fsyr2k.C
+++ b/tests/test-fsyr2k.C
@@ -105,6 +105,7 @@ bool check_fsyr2k (const Field &F, size_t n, size_t k,
     }
 
     FFLAS::fflas_delete(A);
+    FFLAS::fflas_delete(B);
     FFLAS::fflas_delete(C2);
     FFLAS::fflas_delete(C);
     return ok;

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -176,6 +176,7 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
     }
     if (!ok){
         std::cerr<<"Scaling failed"<<std::endl;
+        FFLAS::fflas_delete(A, B, C, C2, D);
         return ok;
     }
 
@@ -200,6 +201,7 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
         cout << "FAILED ("<<time<<")"<<endl;
 
     FFLAS::fflas_delete(A);
+    FFLAS::fflas_delete(B);
     FFLAS::fflas_delete(C2);
     FFLAS::fflas_delete(C);
     FFLAS::fflas_delete(D);
@@ -300,7 +302,7 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
         std::cerr<<"Scaling failed"<<std::endl;
         std::cerr<<"alpha = "<<alpha<<" beta="<<beta<<std::endl;
         std::cerr<<"tb = "<<tb<<std::endl;
-
+        FFLAS::fflas_delete(A, B, C, C2, D);
         return ok;
     }
 
@@ -329,6 +331,7 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
     //cerr<<"FAILED ("<<time<<")"<<endl;
 
     FFLAS::fflas_delete(A);
+    FFLAS::fflas_delete(B);
     FFLAS::fflas_delete(C2);
     FFLAS::fflas_delete(C);
     FFLAS::fflas_delete(D);

--- a/tests/test-nullspace.C
+++ b/tests/test-nullspace.C
@@ -91,6 +91,7 @@ bool test_nullspace(Field& F, FFLAS::FFLAS_SIDE side, size_t m, size_t n, size_t
     size_t NSdim = 0u;
     typename Field::Element_ptr NS;
     FFPACK::NullSpaceBasis(F, side, m, n, ACopy, lda, NS, ldns, NSdim);
+    FFLAS::fflas_delete(ACopy);
 
 #if defined(__FFLAS_FFPACK_DEBUG)
     std::cout << std::endl;
@@ -103,7 +104,9 @@ bool test_nullspace(Field& F, FFLAS::FFLAS_SIDE side, size_t m, size_t n, size_t
         // Ensure nullspace is full rank
         auto NSCopy = FFLAS::fflas_new(F, n, NSdim);
         FFLAS::fassign(F, n, NSdim, NS, NSdim, NSCopy, NSdim);
-        if (FFPACK::Rank(F, n, NSdim, NSCopy, NSdim) != NSdim) return false;
+        size_t rank = FFPACK::Rank(F, n, NSdim, NSCopy, NSdim);
+        FFLAS::fflas_delete(NSCopy);
+        if (rank != NSdim) return false;
 
         // Check that NS is a nullspace
         auto C = FFLAS::fflas_new(F, m, NSdim);
@@ -118,7 +121,9 @@ bool test_nullspace(Field& F, FFLAS::FFLAS_SIDE side, size_t m, size_t n, size_t
         // Ensure nullspace is full rank
         auto NSCopy = FFLAS::fflas_new(F, NSdim, m);
         FFLAS::fassign(F, NSdim, m, NS, m, NSCopy, m);
-        if (FFPACK::Rank(F, NSdim, m, NSCopy, m) != NSdim) return false;
+        size_t rank = FFPACK::Rank(F, NSdim, m, NSCopy, m);
+        FFLAS::fflas_delete(NSCopy);
+        if (rank != NSdim) return false;
 
         // Check that NS is a nullspace
         auto C = FFLAS::fflas_new(F, NSdim, n);

--- a/tests/test-rpm.C
+++ b/tests/test-rpm.C
@@ -79,6 +79,7 @@ bool checkSymmetricRPM (size_t N, size_t R){
                 ok=false;
                 cerr<<"A["<<i<<", "<<j<<"] = "<<A[i*N+j]<<" != A["<<j<<", "<<i<<"]"<<std::endl;
             }
+    fflas_delete(A);
 
     if (!ok){
         std::cerr<<"RPM FAILED"<<std::endl;


### PR DESCRIPTION
While investigating a failure of test-solve on a Fedora Rawhide x86_64 machine, I built fflas-ffpack with -fsanitize=address.  This sadly did not resolve the test-solve problem, but did turn up several memory leaks, which this commit fixes.  The last two hunks of the ffpack_frobenius.inl change are to move the deletion of K up from the end of the while loop to the top, since K already points to allocated memory when the loop is first entered.  The ffpack_invert.inl change stems from the sanitizer complaining that P and Q were allocated with malloc(), then deallocated with delete instead of free().  The rest appear to be simple omissions.