### PR TITLE
Delayed pre-computations in fsyrk-Strassen

### DIFF
--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -100,18 +100,24 @@ int main(int argc, char** argv) {
                 fsyrk (F, uplo, FflasNoTrans, n, k, F.one, A, lda, D, 1, twoBlocks, F.zero, C, ldc, threshold);
                 break;
             case 3: // fsyrk with Strassen and no diagonal scaling
-                Givaro::Integer a,b;
-                Givaro::IntSqrtModDom<> ISM;
-                ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
-                typename Field::Element y1, y2;
-                F.init (y1, a);
-                F.init (y2, b);
+                // Givaro::Integer a,b;
+                // Givaro::IntSqrtModDom<> ISM;
+                // ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
+                // typename Field::Element y1, y2;
+                // F.init (y1, a);
+                // F.init (y2, b);
+            {
                 size_t reclevel = 0;
                 size_t dim = n;
                 while(dim > threshold) {reclevel++; dim>>=1;}
                 MMHelper<Field, MMHelperAlgo::Winograd> H(F,reclevel);
-                fsyrk_strassen (F, uplo, FflasNoTrans, n, k, y1, y2, F.one, A, lda, F.zero, C, ldc, H);
+                fsyrk (F, uplo, FflasNoTrans, n, k, F.one, A, lda, F.zero, C, ldc, H);
                 break;
+            }
+            case 4: // cblas_dsyrk
+                cblas_dsyrk (CblasRowMajor, (CBLAS_UPLO) uplo, (CBLAS_TRANSPOSE) FflasNoTrans, n, k, 1.0, A, lda, 0.0, C, ldc);
+                break;
+
         }
         if (i) chrono.stop();
 

--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -118,7 +118,10 @@ int main(int argc, char** argv) {
                 cblas_dsyrk (CblasRowMajor, (CBLAS_UPLO) uplo, (CBLAS_TRANSPOSE) FflasNoTrans, n, k, 1.0, A, lda, 0.0, C, ldc);
                 break;
             case 5: // fsyrk with the classic Divide and conquer algorithm
-                MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag> H(F,0);
+                size_t reclevel = 0;
+                size_t dim = n;
+                while(dim > threshold) {reclevel++; dim>>=1;}
+                MMHelper<Field, MMHelperAlgo::DivideAndConquer> H(F,reclevel);
                 fsyrk (F, uplo, FflasNoTrans, n, k, F.one, A, lda, F.zero, C, ldc, H);
                 break;
         }

--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -117,7 +117,10 @@ int main(int argc, char** argv) {
             case 4: // cblas_dsyrk
                 cblas_dsyrk (CblasRowMajor, (CBLAS_UPLO) uplo, (CBLAS_TRANSPOSE) FflasNoTrans, n, k, 1.0, A, lda, 0.0, C, ldc);
                 break;
-
+            case 5: // fsyrk with the classic Divide and conquer algorithm
+                MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag> H(F,0);
+                fsyrk (F, uplo, FflasNoTrans, n, k, F.one, A, lda, F.zero, C, ldc, H);
+                break;
         }
         if (i) chrono.stop();
 

--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -109,7 +109,8 @@ int main(int argc, char** argv) {
                 size_t reclevel = 0;
                 size_t dim = n;
                 while(dim > threshold) {reclevel++; dim>>=1;}
-                fsyrk_strassen (F, uplo, FflasNoTrans, n, k, y1, y2, F.one, A, lda, F.zero, C, ldc, reclevel);
+                MMHelper<Field, MMHelperAlgo::Winograd> H(F,reclevel);
+                fsyrk_strassen (F, uplo, FflasNoTrans, n, k, y1, y2, F.one, A, lda, F.zero, C, ldc, H);
                 break;
         }
         if (i) chrono.stop();

--- a/benchmarks/benchmark-fsyrk.C
+++ b/benchmarks/benchmark-fsyrk.C
@@ -26,7 +26,6 @@
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include <iostream>
 #include <givaro/modular.h>
-#include <givaro/givintsqrootmod.h>
 
 #include "fflas-ffpack/fflas-ffpack.h"
 #include "fflas-ffpack/utils/timer.h"
@@ -100,12 +99,6 @@ int main(int argc, char** argv) {
                 fsyrk (F, uplo, FflasNoTrans, n, k, F.one, A, lda, D, 1, twoBlocks, F.zero, C, ldc, threshold);
                 break;
             case 3: // fsyrk with Strassen and no diagonal scaling
-                // Givaro::Integer a,b;
-                // Givaro::IntSqrtModDom<> ISM;
-                // ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
-                // typename Field::Element y1, y2;
-                // F.init (y1, a);
-                // F.init (y2, b);
             {
                 size_t reclevel = 0;
                 size_t dim = n;

--- a/fflas-ffpack/fflas/Makefile.am
+++ b/fflas-ffpack/fflas/Makefile.am
@@ -53,6 +53,7 @@ pkgincludesub_HEADERS=       \
 	   fflas_pftrsm.inl      \
 	   fflas_ftrsm.inl       \
 	   fflas_fsyrk.inl       \
+	   fflas_fsyrk_strassen.inl       \
 	   fflas_fsyr2k.inl       \
 	   fflas_fgemv.inl       \
 	   fflas_freivalds.inl       \

--- a/fflas-ffpack/fflas/fflas.h
+++ b/fflas-ffpack/fflas/fflas.h
@@ -112,6 +112,7 @@
 #include "fflas_freivalds.inl"
 #include "fflas_fger.inl"
 #include "fflas_fsyrk.inl"
+#include "fflas_fsyrk_strassen.inl"
 #include "fflas_fsyr2k.inl"
 #include "fflas_ftrsm.inl"
 #include "fflas_pftrsm.inl"

--- a/fflas-ffpack/fflas/fflas_fadd.h
+++ b/fflas-ffpack/fflas/fflas_fadd.h
@@ -256,6 +256,26 @@ namespace FFLAS {
 
     template <class Field>
     void
+    faddin (const Field& F,
+            const FFLAS_UPLO uplo,
+            const size_t N,
+            typename Field::ConstElement_ptr B, const size_t ldb,
+            typename Field::Element_ptr C, const size_t ldc)
+    {
+        const typename Field::Element  *Bi = B;
+        typename Field::Element_ptr Ci = C;
+        if (uplo == FflasUpper){
+            for (size_t i=N; i>0; --i,  Bi+=ldb+1, Ci+=ldc+1)
+                faddin(F,i,Bi,1,Ci,1);
+        } else {
+            for (size_t i=1; i <= N; ++i, Bi+=ldb, Ci+=ldc)
+                faddin(F,i,Bi,1,Ci,1);
+        }
+    }
+
+
+    template <class Field>
+    void
     fsubin (const Field& F, const size_t M, const size_t N,
             typename Field::ConstElement_ptr B, const size_t ldb,
             typename Field::Element_ptr C, const size_t ldc)

--- a/fflas-ffpack/fflas/fflas_fadd.inl
+++ b/fflas-ffpack/fflas/fflas_fadd.inl
@@ -304,11 +304,13 @@ namespace FFLAS { namespace details {
                 FFLAS::vectorised::subp<!FieldTraits<Field>::balanced>(C,A,B,N,p,F.minElement(),F.maxElement());
         }
         else {
-            for (size_t i=0; i<N; i++)
+            typename Field::ConstElement_ptr Ai=A, Bi=B;
+            typename Field::Element_ptr Ci=C;
+            for (size_t i=0; i<N; i++, Ai+=inca, Bi+=incb, Ci+=incc)
                 if (ADD)
-                    F.add (C[i*incc], A[i*inca], B[i*incb]);
+                    F.add (*Ci, *Ai, *Bi);
                 else
-                    F.sub (C[i*incc], A[i*inca], B[i*incb]);
+                    F.sub (*Ci, *Ai, *Bi);
         }
     }
 
@@ -329,11 +331,13 @@ namespace FFLAS { namespace details {
                     F.sub (C[i], A[i], B[i]);
         }
         else {
-            for (size_t i=0; i<N; i++)
+            typename Field::ConstElement_ptr Ai=A, Bi=B;
+            typename Field::Element_ptr Ci=C;
+            for (size_t i=0; i<N; i++, Ai+=inca, Bi+=incb, Ci+=incc)
                 if (ADD)
-                    F.add (C[i*incc], A[i*inca], B[i*incb]);
+                    F.add (*Ci, *Ai, *Bi);
                 else
-                    F.sub (C[i*incc], A[i*inca], B[i*incb]);
+                    F.sub (*Ci, *Ai, *Bi);
         }
     }
 
@@ -357,11 +361,13 @@ namespace FFLAS { namespace details {
             }
         }
         else {
-            for (size_t i=0; i<N; i++)
+            typename Field::ConstElement_ptr Ai=A, Bi=B;
+            typename Field::Element_ptr Ci=C;
+            for (size_t i=0; i<N; i++, Ai+=inca, Bi+=incb, Ci+=incc)
                 if (ADD)
-                    F.add (C[i*incc], A[i*inca], B[i*incb]);
+                    F.add (*Ci, *Ai, *Bi);
                 else
-                    F.add (C[i*incc], A[i*inca], B[i*incb]);
+                    F.add (*Ci, *Ai, *Bi);
         }
     }
 
@@ -374,11 +380,13 @@ namespace FFLAS { namespace details {
           , FieldCategories::UnparametricTag
          )
     {
-        for (size_t i=0; i<N; i++)
+        typename Field::ConstElement_ptr Ai=A, Bi=B;
+        typename Field::Element_ptr Ci=C;
+        for (size_t i=0; i<N; i++, Ai+=inca,Bi+=incb,Ci+=incc)
             if (ADD)
-                C[i] = A[i] + B[i];
+                *Ci = *Ai + *Bi;
             else
-                C[i] = A[i] - B[i];
+                *Ci = *Ai - *Bi;
     }
 
     template <class Field, bool ADD>
@@ -396,11 +404,13 @@ namespace FFLAS { namespace details {
             else
                 FFLAS::vectorised::sub(C,A,B,N);
         } else {
-            for (size_t i=0; i<N; i++)
+            typename Field::ConstElement_ptr Ai=A, Bi=B;
+            typename Field::Element_ptr Ci=C;
+            for (size_t i=0; i<N; i++, Ai+=inca,Bi+=incb,Ci+=incc)
                 if (ADD)
-                    C[i] = A[i] + B[i];
+                    *Ci = *Ai + *Bi;
                 else
-                    C[i] = A[i] - B[i];
+                    *Ci = *Ai - *Bi;
         }
     }
 

--- a/fflas-ffpack/fflas/fflas_fdot.inl
+++ b/fflas-ffpack/fflas/fflas_fdot.inl
@@ -67,9 +67,12 @@ namespace FFLAS {
 
         const DFElt MaxStorableValue = limits<typename DelayedField::Element>::max();
         const DFElt AbsMax = std::max(-F.minElement(), F.maxElement());
-        const DFElt r = MaxStorableValue / (AbsMax*AbsMax);
+        const DFElt r = MaxStorableValue / AbsMax/AbsMax;
         size_t delayedDim = FFLAS::Protected::min_types<DFElt>(r);
-
+        if (!delayedDim){
+            ModeCategories::DefaultTag DT;
+            return fdot(F, N, x, incx, y, incy, DT);
+        }
         typename Field::Element d;
         F.init (d);
         F.assign (d, F.zero);

--- a/fflas-ffpack/fflas/fflas_fgemm.inl
+++ b/fflas-ffpack/fflas/fflas_fgemm.inl
@@ -429,7 +429,7 @@ namespace FFLAS {
         fgemm (F, ta, tb, m, n, k, alpha_, A, lda, B, ldb, beta_, C, ldc, HD);
 
         Protected::ScalAndReduce (F, m, n, alpha, C, ldc, HD);
-
+        
         H.initOut();
 
         return C;

--- a/fflas-ffpack/fflas/fflas_freduce.h
+++ b/fflas-ffpack/fflas/fflas_freduce.h
@@ -151,6 +151,21 @@ namespace FFLAS {
     }
     template<class Field>
     void
+    freduce (const Field& F, const FFLAS_UPLO UpLo,
+             const size_t m , const size_t n,
+             typename Field::Element_ptr A, const size_t lda)
+    {
+        if (UpLo == FflasUpper){
+            for (size_t i = 0 ; i < m ; ++i)
+                freduce (F, n-i, A+i*(lda+1), 1);
+        } else { // Lower
+            for (size_t i = 0 ; i < m ; ++i)
+                freduce (F, i+1, A+i*lda, 1);
+        }
+        return;
+    }
+    template<class Field>
+    void
     pfreduce (const Field& F, const size_t m , const size_t n,
               typename Field::Element_ptr A, const size_t lda, const size_t numths)
     {

--- a/fflas-ffpack/fflas/fflas_freduce.h
+++ b/fflas-ffpack/fflas/fflas_freduce.h
@@ -155,6 +155,7 @@ namespace FFLAS {
              const size_t m , const size_t n,
              typename Field::Element_ptr A, const size_t lda)
     {
+        assert(m<=n); // otherwise n-i or i+1 might go out of range
         if (UpLo == FflasUpper){
             for (size_t i = 0 ; i < m ; ++i)
                 freduce (F, n-i, A+i*(lda+1), 1);

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -255,7 +255,7 @@ namespace FFLAS {
                 H.initA();
                 freduce_constoverride (F, (trans==FflasNoTrans)?N:K, (trans==FflasNoTrans)?K:N, A, lda);
             }
-            if (H.Cmin < H.FieldMin || H.Cmax>H.FieldMax){
+            if (!F.isZero(beta) && (H.Cmin < H.FieldMin || H.Cmax>H.FieldMax)){
                 H.initC();
                 freduce (F, UpLo, N, N, C, ldc);
             }

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -332,7 +332,6 @@ namespace FFLAS {
             remblock = kmax;
             --nblock;
         }
-
         size_t shiftA;
         if (trans == FflasTrans) shiftA = k2*lda;
         else shiftA = k2;
@@ -453,7 +452,7 @@ namespace FFLAS {
         MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag>  Hd(H);
         fsyrk (F, UpLo, trans, N, K, alpha, A, lda, beta, C, ldc, Hd);
         H.setOutBounds (K,alpha,beta);
-        return C;
+       return C;
     }
 
     inline Givaro::FloatDomain::Element_ptr
@@ -467,8 +466,8 @@ namespace FFLAS {
            const Givaro::FloatDomain::Element beta,
            Givaro::FloatDomain::Element_ptr C, const size_t ldc,
            MMHelper<Givaro::FloatDomain, MMHelperAlgo::Classic, ModeCategories::DefaultTag> &H) {
-            // std::cerr<<"fsyrk Classic Default FloatDomain"<<std::endl;
-        cblas_ssyrk (CblasRowMajor, (CBLAS_UPLO) UpLo, (CBLAS_TRANSPOSE) trans, N, K, alpha, A, lda, beta, C, ldc);
+            //std::cerr<<"fsyrk Classic Default FloatDomain"<<std::endl;
+         cblas_ssyrk (CblasRowMajor, (CBLAS_UPLO) UpLo, (CBLAS_TRANSPOSE) trans, N, K, alpha, A, lda, beta, C, ldc);
         return C;
     }
 

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -278,6 +278,13 @@ namespace FFLAS {
         if (!N) return C;
         if (!K || F.isZero (alpha)){
             fscalin(F, N, N, beta, C, ldc);
+            if (beta> 0){
+                H.Outmin = H.Cmin * beta;
+                H.Outmax = H.Cmax * beta;
+            }else{
+                H.Outmin = H.Cmax * beta;
+                H.Outmax = H.Cmin * beta;
+            }
             return C;
         }
             //std::cerr<<"fsyrk Classic Lazy"<<std::endl;

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -40,6 +40,7 @@ namespace FFLAS{namespace Protected{
                    typename Field::Element_ptr C, const size_t ldc,
                    MMHelper<Field, MMHelperAlgo::Classic, FieldMode> & H)
     {
+            //std::cerr<<"fsyrk_convert"<<std::endl;
         typedef typename NewField::Element FloatElement;
         NewField G((FloatElement) F.characteristic());
         FloatElement tmp,alphaf, betaf;
@@ -88,6 +89,7 @@ namespace FFLAS {
            const typename Field::Element beta,
            typename Field::Element_ptr C, const size_t ldc)
     {
+            //std::cerr<<"fsyrk nothing"<<std::endl;
         if (!N) return C;
         if (!K || F.isZero (alpha)){
             fscalin(F, N, N, beta, C, ldc);
@@ -111,6 +113,7 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            const ParSeqHelper::Sequential seq )
     {
+            //std::cerr<<"fsyrk PSH::Seq"<<std::endl;
         MMHelper<Field, MMHelperAlgo::Classic, typename FFLAS::ModeTraits<Field>::value, ParSeqHelper::Sequential > HW (F, N, K, N, seq);
         return fsyrk (F, UpLo, trans, N, K, alpha, A, lda, beta, C, ldc, HW);
     }
@@ -128,6 +131,7 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::ConvertTo<ElementCategories::MachineFloatTag>, ParSeqHelper::Sequential> & H)
      {
+             //std::cerr<<"fsyrk Classic ConvertTo"<<std::endl;
          if (!std::is_same<Field,Givaro::Modular<float> >::value){
             if (F.cardinality() == 2)
                 return Protected::fsyrk_convert<Givaro::Modular<float>,Field>(F,UpLo,trans,N,K,alpha,A,lda,beta,C,ldc,H);
@@ -158,6 +162,7 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DelayedTag> & H)
     {
+            //std::cerr<<"fsyrk Classic Delayed"<<std::endl;
         
         typename Field::Element alpha_,beta_;
         if ( !F.isOne(alpha) && !F.isMOne(alpha)){
@@ -192,6 +197,7 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::LazyTag> & H)
     {
+            //std::cerr<<"fsyrk Classic Lazy"<<std::endl;
         // Input matrices are unreduced: need to figure out the best option between:
         // - reducing them
         // - making possibly more blocks (smaller kmax)
@@ -306,6 +312,8 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag> & H) {
 
+            //std::cerr<<"fsyrk Classic Default Field"<<std::endl;
+
         //@TODO: write an optimized iterative basecase
         if (N==1){ // Base case
             F.mulin (*C, beta);
@@ -355,6 +363,8 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultBoundedTag> & H) {
 
+            //std::cerr<<"fsyrk Classic DefaultBounded"<<std::endl;
+
         MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag>  Hd(H);
         fsyrk (F, UpLo, trans, N, K, alpha, A, lda, beta, C, ldc, Hd);
         H.setOutBounds (K,alpha,beta);
@@ -372,6 +382,7 @@ namespace FFLAS {
            const Givaro::FloatDomain::Element beta,
            Givaro::FloatDomain::Element_ptr C, const size_t ldc,
            MMHelper<Givaro::FloatDomain, MMHelperAlgo::Classic, ModeCategories::DefaultTag> &H) {
+            //std::cerr<<"fsyrk Classic Default FloatDomain"<<std::endl;
         cblas_ssyrk (CblasRowMajor, (CBLAS_UPLO) UpLo, (CBLAS_TRANSPOSE) trans, N, K, alpha, A, lda, beta, C, ldc);
         return C;
     }
@@ -387,6 +398,7 @@ namespace FFLAS {
            const Givaro::DoubleDomain::Element beta,
            Givaro::DoubleDomain::Element_ptr C, const size_t ldc,
            MMHelper<Givaro::DoubleDomain, MMHelperAlgo::Classic, ModeCategories::DefaultTag> &H) {
+            //std::cerr<<"fsyrk Classic Default DoubleDomain"<<std::endl;
         cblas_dsyrk (CblasRowMajor, (CBLAS_UPLO) UpLo, (CBLAS_TRANSPOSE) trans, N, K, alpha, A, lda, beta, C, ldc);
         return C;
     }

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -378,7 +378,7 @@ namespace FFLAS {
             H.Outmin = Hfp.Outmin;
             H.Outmax = Hfp.Outmax;
         }
-        H.checkOut(F,N,N,C,ldc);
+        H.checkOut(F, UpLo, N, N, C, ldc);
         return C;
     }
 

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -240,6 +240,11 @@ namespace FFLAS {
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DelayedTag> & H)
     {
             //std::cerr<<"fsyrk Classic Delayed"<<std::endl;
+        if (!N) return C;
+        if (!K || F.isZero (alpha)){
+            fscalin(F, N, N, beta, C, ldc);
+            return C;
+        }
         
         typename Field::Element alpha_,beta_;
         if ( !F.isOne(alpha) && !F.isMOne(alpha)){
@@ -274,6 +279,11 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::LazyTag> & H)
     {
+        if (!N) return C;
+        if (!K || F.isZero (alpha)){
+            fscalin(F, N, N, beta, C, ldc);
+            return C;
+        }
             //std::cerr<<"fsyrk Classic Lazy"<<std::endl;
         // Input matrices are unreduced: need to figure out the best option between:
         // - reducing them
@@ -326,6 +336,7 @@ namespace FFLAS {
             remblock = kmax;
             --nblock;
         }
+
         size_t shiftA;
         if (trans == FflasTrans) shiftA = k2*lda;
         else shiftA = k2;
@@ -460,7 +471,7 @@ namespace FFLAS {
            const Givaro::FloatDomain::Element beta,
            Givaro::FloatDomain::Element_ptr C, const size_t ldc,
            MMHelper<Givaro::FloatDomain, MMHelperAlgo::Classic, ModeCategories::DefaultTag> &H) {
-            //std::cerr<<"fsyrk Classic Default FloatDomain"<<std::endl;
+            // std::cerr<<"fsyrk Classic Default FloatDomain"<<std::endl;
         cblas_ssyrk (CblasRowMajor, (CBLAS_UPLO) UpLo, (CBLAS_TRANSPOSE) trans, N, K, alpha, A, lda, beta, C, ldc);
         return C;
     }

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -317,6 +317,7 @@ namespace FFLAS {
             // Might as well reduce inputs
             if (H.Amin < H.FieldMin || H.Amax>H.FieldMax){
                 H.initA();
+                H.initB();
                 freduce_constoverride (F, (trans==FflasNoTrans)?N:K, (trans==FflasNoTrans)?K:N, A, lda);
             }
             if (!F.isZero(beta) && (H.Cmin < H.FieldMin || H.Cmax>H.FieldMax)){

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -421,15 +421,12 @@ namespace FFLAS {
             fsyrk (F, UpLo, trans, N1, K, alpha, A, lda, beta, C, ldc, CH);
             // C22 <- alpha A2 x A2^T + beta C22
             fsyrk (F, UpLo, trans, N2, K, alpha, A2, lda, beta, C22, ldc, CH);
-
             if (UpLo == FflasUpper) {
-                    // CP : calling explicitely with H to shortcut Winograd's algorithm in fgemm,
-                    // since it does not compile with Field=ZRing<int64_t>
                 // C12 <- alpha A1 * A2^T + beta C12
-                fgemm (F, trans, oppTrans, N1, N2, K, alpha, A, lda, A2, lda, beta, C12, ldc, H);
+                fgemm (F, trans, oppTrans, N1, N2, K, alpha, A, lda, A2, lda, beta, C12, ldc);
             } else {
                 // C21 <- alpha A2 * A1^T + beta C21
-                fgemm (F, trans, oppTrans, N2, N1, K, alpha, A2, lda, A, lda, beta, C21, ldc, H);
+                fgemm (F, trans, oppTrans, N2, N1, K, alpha, A2, lda, A, lda, beta, C21, ldc);
             }
             return C;
         }

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -338,7 +338,6 @@ namespace FFLAS {
            MMHelper<Field, MMHelperAlgo::Classic, ModeCategories::DefaultTag> & H) {
 
             //std::cerr<<"fsyrk Classic Default Field"<<std::endl;
-
         //@TODO: write an optimized iterative basecase
         if (N==1){ // Base case
             F.mulin (*C, beta);
@@ -358,18 +357,18 @@ namespace FFLAS {
             typename Field::Element_ptr C21 = C + N1*ldc;
             typename Field::Element_ptr C22 = C12 + N1*ldc;
             // C11 <- alpha A1 x A1^T + beta C11
-            fsyrk (F, UpLo, trans, N1, K, alpha, A, lda, beta, C, ldc);
+            fsyrk (F, UpLo, trans, N1, K, alpha, A, lda, beta, C, ldc, H);
             // C22 <- alpha A2 x A2^T + beta C22
-            fsyrk (F, UpLo, trans, N2, K, alpha, A2, lda, beta, C22, ldc);
+            fsyrk (F, UpLo, trans, N2, K, alpha, A2, lda, beta, C22, ldc, H);
 
             if (UpLo == FflasUpper) {
                     // CP : calling explicitely with H to shortcut Winograd's algorithm in fgemm,
                     // since it does not compile with Field=ZRing<int64_t>
                 // C12 <- alpha A1 * A2^T + beta C12
-                fgemm (F, trans, oppTrans, N1, N2, K, alpha, A, lda, A2, lda, beta, C12, ldc, H);
+                fgemm (F, trans, oppTrans, N1, N2, K, alpha, A, lda, A2, lda, beta, C12, ldc);
             } else {
                 // C21 <- alpha A2 * A1^T + beta C21
-                fgemm (F, trans, oppTrans, N2, N1, K, alpha, A2, lda, A, lda, beta, C21, ldc, H);
+                fgemm (F, trans, oppTrans, N2, N1, K, alpha, A2, lda, A, lda, beta, C21, ldc);
             }
             return C;
         }
@@ -456,7 +455,6 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            const ParSeqHelper::Sequential seq,
            const size_t threshold){
-
         size_t incRow,incCol;
         FFLAS_TRANSPOSE oppTrans;
         if (trans==FflasNoTrans) {incRow=lda;incCol=1;oppTrans=FflasTrans;}

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -134,7 +134,7 @@ namespace FFLAS {
                         F.mulin (C[i*ldc+j],beta);
                         F.axpyin (C[i*ldc+j],
                                   alpha,
-                                  fdot(F, K, A+i*lda, 1, A+j, lda));
+                                  fdot(F, K, A+i*lda, 1, A+j*lda, 1));
                     }
             } else { // Trans
                 for (size_t i=0; i<N; i++)
@@ -142,7 +142,7 @@ namespace FFLAS {
                         F.mulin (C[i*ldc+j],beta);
                         F.axpyin (C[i*ldc+j],
                                   alpha,
-                                  fdot(F, K, A+i, lda, A+j*lda, 1));
+                                  fdot(F, K, A+i, lda, A+j, lda));
                     }
             }
         } else { // Lower
@@ -152,7 +152,7 @@ namespace FFLAS {
                         F.mulin (C[i*ldc+j],beta);
                         F.axpyin (C[i*ldc+j],
                                   alpha,
-                                  fdot(F, K, A+i*lda, 1, A+j, lda));
+                                  fdot(F, K, A+i*lda, 1, A+j*lda, 1));
                     }
             } else { // Trans
                 for (size_t i=0; i<N; i++)
@@ -160,7 +160,7 @@ namespace FFLAS {
                         F.mulin (C[i*ldc+j],beta);
                         F.axpyin (C[i*ldc+j],
                                   alpha,
-                                  fdot(F, K, A+i, lda, A+j*lda, 1));
+                                  fdot(F, K, A+i, lda, A+j, lda));
                     }
             }
         }

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -201,11 +201,9 @@ namespace FFLAS {
         DFElt S1min, S1max, S2min, S2max, S2minr, S2maxr, S3min, S3max, Smin, Smax, Sminr, Smaxr, Tmin, Tmax;
             // Should we reduce Axx and Sx beforehand?
         bool reduceA21 = false;
-        // std::cerr<<"Bmin = "<<WH.Bmin <<" Bmax = "<<WH.Bmax<<std::endl;
         if (Protected::NeedPreScalReduction (S1min, S1max, WH.Bmin, WH.Bmax, x, WH)){
             reduceA21 = true;
         }
-        // std::cerr<<"reduceA21 = "<<reduceA21<<" S1min = "<<S1min<<" S1max = "<<S1max<<std::endl;
         bool reduceS1 = false;
         bool redS1 = Protected::NeedPreAxpyReduction (S2min, S2max, S1min, S1max, WH.Bmin, WH.Bmax, y, WH);
         bool redS1r = Protected::NeedPreAxpyReduction (S2minr, S2maxr, S1min, S1max, WH.Bmin, WH.Bmax, negy, WH);
@@ -215,18 +213,14 @@ namespace FFLAS {
         }
         if (S2minr < S2min) S2min = S2minr;
         if (S2maxr > S2max) S2max = S2maxr;
-        
-        // std::cerr<<"reduceS1 = "<<reduceS1<<" S1min = "<<S1min<<" S1max = "<<S1max<<std::endl;
+
         bool reduceS2 = false;
         bool reduceA11 = false;
         if (Protected::NeedPreAxpyReduction (S3min, S3max, S2min, S2max, WH.Amin, WH.Amax, negx, WH)){
             reduceS2 = true;
             reduceA11 = true;
         }
-        // std::cerr<<"reduceS2 = "<<reduceS2<<" S2min = "<<S2min<<" S2max = "<<S2max<<std::endl;
         bool reduceS3 = false;
-        // std::cerr<<"S3min = "<<S3min<<" S3max = "<<S3max<<" WH.Amin = "<<WH.Amin<<" WH.Amax = "<<WH.Amax
-        //          <<" negy = "<<negy<<std::endl;
         bool redS3 = Protected::NeedPreAxpyReduction (Smin, Smax, S3min, S3max, WH.Amin, WH.Amax, negy, WH);
         bool redS3r = Protected::NeedPreAxpyReduction (Sminr, Smaxr, S3min, S3max, WH.Amin, WH.Amax, y, WH);
         if (redS3 || redS3r) {
@@ -235,8 +229,7 @@ namespace FFLAS {
         if (Smin > Sminr) Smin = Sminr;
         if (Smax < Smaxr) Smax = Smaxr;
         
-        // std::cerr<<"reduceS3 = "<<reduceS3<<" Smin = "<<Smin<<" Smax = "<<Smax<<std::endl;
-         bool reduceA22 = false;
+        bool reduceA22 = false;
         if (Protected::NeedPreSubReduction (Tmin, Tmax, WH.Cmin, WH.Cmax, S2min, S2max, WH)) {
             reduceA22 = true;
                 // TODO: shouldn't we also reduce S2?
@@ -255,9 +248,7 @@ namespace FFLAS {
                     fscal (DF, K2, x, A21, 1, S, 1);
 
                 if (!F.isZero(y)){
-                    // std::cerr<<" S1 ("<<*S<<") + negy ("<<negy<<") * A21r("<<*A21r<<") = ";
                     faxpy (DF, K4, negy, A21r, 1, S, 1);
-                    // std::cerr<<*S<<std::endl;
                     faxpy (DF, K4, y, A21, 1, Sr, 1);
                     if (reduceS2)
                         freduce (F, K2, S, 1);
@@ -270,22 +261,14 @@ namespace FFLAS {
                     freduce (F, K2, T, 1);
                 }
                     // S <- S - A11 Y
-                // WriteMatrix(std::cerr<<"S2 = "<<std::endl, F, 1, K2, S, K2);
-                // std::cerr<<" S2 ("<<*S<<") + negx ("<<negx<<") * A11("<<*A11<<") = ";
                 faxpy (DF, K2, negx, A11, 1, S, 1);
-                // std::cerr<<*S<<std::endl;
-                // WriteMatrix(std::cerr<<"S3 = "<<std::endl, F, 1, K2, S, K2);
                 if (reduceS3 || F.isZero(y))
                     freduce (F, K2, S, 1);
-                // WriteMatrix(std::cerr<<"S3 mod p = "<<std::endl, F, 1, K2, S, K2);
                 if (!F.isZero(y)){
-                    // std::cerr<<" S3 ("<<*S<<") + y ("<<y<<") * A11r("<<*A11r<<") = ";
                     faxpy (DF, K4, y, A11r, 1, S, 1);
-                    // std::cerr<<*S<<std::endl;
                     faxpy (DF, K4, negy, A11, 1, Sr, 1);
                     freduce (F, K2, S, 1);
                 }
-                    //freduce (F,K2,S, 1);
             }
         } else { // FflasTrans         
             for (size_t i=0; i<K4; ++i, A11+=lda, A11r+=lda, A21+=lda, A21r+=lda, A22+=lda, A22r+=lda, S+=lds, Sr+=lds, T+=ldt, Tr+=ldt){
@@ -328,10 +311,7 @@ namespace FFLAS {
                     faxpy (DF, N2, negy, A11, 1, Sr, 1);
                     freduce (F,N2,Sr, 1);
                 }
-                    // freduce (F,N2,T, 1);
-                    // freduce (F,N2,Tr, 1);
             }
-            
         }
     }
 

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -338,7 +338,7 @@ namespace FFLAS {
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"A11 = "<<std::endl, F, N2, K2, A11, lda);
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S1 = "<<std::endl, F, N2, K2, C21, ldc);
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S2 = "<<std::endl, F, N2, K2, C12, ldc);
-            std::cerr<<"x = "<<y1<< " y = "<<y2<<std::endl;
+            //std::cerr<<"x = "<<y1<< " y = "<<y2<<std::endl;
                 //  P4^T =  S2 x S1^T in  C22
             MMH_t H4 (F, -1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
             fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S2, lds, S1, lds, F.zero, C22, ldc, H4);

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -139,7 +139,7 @@ namespace FFLAS {
         // fsubin (F, N2, K2, A22, lda, T, ldt);
 
             // S <- A21 Y^T
-        for (size_t i=0; i<N2; ++i, A11+=lda, A11r+=lda, A21+=lda, A21r+=lda, S+=lds, Sr+=lds, T+=ldt){
+        for (size_t i=0; i<N2; ++i, A11+=lda, A11r+=lda, A21+=lda, A21r+=lda, A22+=lda, S+=lds, Sr+=lds, T+=ldt){
             fscal (DF, K2, x, A21, 1, S, 1);
             if (!F.isZero(y)){
                 faxpy (DF, K4, negy, A21r, 1, S, 1);
@@ -289,7 +289,9 @@ namespace FFLAS {
                     typename Field::Element_ptr C, const size_t ldc,
                     MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait> & WH
                     ) {
-            //std::cerr<<"fsyrk_strassen"<<std::endl;
+        // std::cerr<<"Entree fsyrk_strassen"
+        //          <<" WH = "<<WH
+        //          <<std::endl;
             // written for NoTrans, Lower
         if (WH.recLevel == 0){
             MMHelper<Field, MMHelperAlgo::Classic, FieldTrait>  CH(WH);

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -154,7 +154,6 @@ namespace FFLAS {
         const typename MMH_t::DelayedField & DF = WH.delayedField;
         typedef typename  MMH_t::DelayedField::Element DFElt;
 
-        // std::cerr<<"#COMPUTES1S2: A21min = "<<WH.Bmin<<" A21max = "<<WH.Bmax<<" A11min = "<<WH.Amin<<" A11max = "<<WH.Amax<<std::endl;
         size_t N2 = N>>1;
         size_t K2 = K>>1;
         size_t K4 = K2>>1;
@@ -521,28 +520,8 @@ namespace FFLAS {
                 // S2 =  A22 - A21 x Y  in S2 (C12)
             MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait>  PH(WH);
             PH.Bmin = WH.Amin; PH.Bmax = WH.Amax; PH.Cmin = WH.Amin; PH.Cmax = WH.Amax;
-            // std::cerr<<"##########################################################" <<std::endl;
-            // WriteMatrix(std::cerr<<"A21 = ",F, N2, K2, A21, lda, FflasSageMath);
-            // WriteMatrix(std::cerr<<"A11 = ",F, N2, K2, A, lda, FflasSageMath);
-            // WriteMatrix(std::cerr<<"A12 = ",F, N2, K2, A12, lda, FflasSageMath);
-            // WriteMatrix(std::cerr<<"A22 = ",F, N2, K2, A22, lda, FflasSageMath);
+
             computeS1S2 (F, trans, N, K, y1, y2, A,lda, S1, lds, S2, lds, PH);
-            // std::cerr<<"Y=Matrix(GF("<<F.cardinality()<<"),"<<K2<<","<<K2<<");"<<std::endl;
-            // std::cerr<<"Y[:"<<K2/2<<",:"<<K2/2<<"]="<<y1<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y[:"<<K2/2<<","<<K2/2<<":]="<<y2<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y["<<K2/2<<":,:"<<K2/2<<"]="<<-y2<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y["<<K2/2<<":,"<<K2/2<<":]="<<y1<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"S1 = (A21-A11)*Y; S2 = A22-A21*Y;"<<std::endl;
-            // WriteMatrix(std::cerr<<"S1v = ",F, N2, K2, S1, lds, FflasSageMath);
-            // WriteMatrix(std::cerr<<"S2v = ",F, N2, K2, S2, lds, FflasSageMath);
-            // std::cerr<<"if (S1v != S1):"<<std::endl
-            //          <<"    print S1; print S1v"<<std::endl
-            //          <<"else:"<<std::endl
-            //          <<"    print ('S1 = S1v')"<<std::endl;
-            // std::cerr<<"if (S2v != S2):"<<std::endl
-            //          <<"    print S2;print S2v"<<std::endl
-            //          <<"else:"<<std::endl
-            //          <<"    print ('S2 = S2v')"<<std::endl;
 
                 //  P4^T =  S2 x S1^T in  C22
             MMH_t H4 (F, -1, PH.Outmin, PH.Outmax, PH.Outmin, PH.Outmax, 0,0);
@@ -550,27 +529,19 @@ namespace FFLAS {
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S2, lds, S1, lds, F.zero, C22, ldc, H4);
             else
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S1, lds, S2, lds, F.zero, C22, ldc, H4);
-            // WriteMatrix(std::cerr<<"P4 = ",F,N2,N2,C22,ldc,FflasSageMath);
 
             if (K>N){ fflas_delete(S2); }
 
                 // S3 = S1 - A22 in S1
             fsubin (DF, Arows, Acols, A22, lda, S1, lds);
 
-            // WriteMatrix(std::cerr<<"S3 = ",F,N2,K2,S1,lds,FflasSageMath);
-
                 // P5 = S3 x S3^T in C12
-                // TODO: update the bounds in the helper
             MMH_t H5 (F, WH.recLevel-1, PH.Outmin-PH.Cmax, PH.Outmax-PH.Cmin,
                       PH.Outmin-PH.Cmax, PH.Outmax-PH.Cmin, 0,0);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, S1, lds, F.zero, C12, ldc, H5);
 
-            // WriteMatrix(std::cerr<<"P5 = ",F,N2,N2,C12,ldc,FflasSageMath);
-
                 // S4 = S3 + A12 in S4
             fadd (DF, Arows, Acols, S1, lds, A12, lda, S4, lds);
-
-            // WriteMatrix(std::cerr<<"S4 = ",F,N2,K2,S4,lds,FflasSageMath);
 
                 // P3 = A22 x S4^T in C21
             MMH_t H3 (F, WH.recLevel-1, PH.Cmin, PH.Cmax, PH.Outmin+WH.Bmin-PH.Cmax, PH.Outmax+WH.Bmax-PH.Cmin, 0,0);
@@ -584,16 +555,11 @@ namespace FFLAS {
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S4, lds, A22, lda, F.zero, C21, ldc, H3);
             }
 
-            // WriteMatrix(std::cerr<<"P3 = ",F,N2,N2,C21,ldc,FflasSageMath);
-
             if (K>N){ fflas_delete(S1); }
 
                 // P1 = A11 x A11^T in C11
             MMH_t H1 (F, WH.recLevel-1, PH.Amin, PH.Amax, PH.Amin, PH.Amax, 0,0);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A11, lda, F.zero, C11, ldc, H1);
-
-            // WriteMatrix(std::cerr<<"P1 = ",F,N2,N2,C11,ldc,FflasSageMath);
-            // WriteMatrix(std::cerr<<"P3 = ",F,N2,N2,C21,ldc,FflasSageMath);
 
                 // U1 = P1 + P5 in C12
             DFElt U1Min, U1Max;
@@ -672,29 +638,7 @@ namespace FFLAS {
             MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait>  PH(WH);
             PH.Bmin = WH.Amin; PH.Bmax = WH.Amax; PH.Cmin = WH.Amin; PH.Cmax = WH.Amax;
 
-            //  std::cerr<<"******************************************" <<std::endl;
-            // WriteMatrix(std::cerr<<"A21 = ",F, N2, K2, A21, lda, FflasSageMath);
-            // WriteMatrix(std::cerr<<"A11 = ",F, N2, K2, A, lda, FflasSageMath);
-            // WriteMatrix(std::cerr<<"A22 = ",F, N2, K2, A22, lda, FflasSageMath);
-
             computeS1S2 (F, trans, N, K, y1, y2, A, lda, T, ldt, S2, lds, PH);
-            
-            // std::cerr<<"Y=Matrix(GF("<<F.cardinality()<<"),"<<K2<<","<<K2<<");"<<std::endl;
-            // std::cerr<<"Y[:"<<K2/2<<",:"<<K2/2<<"]="<<y1<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y[:"<<K2/2<<","<<K2/2<<":]="<<y2<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y["<<K2/2<<":,:"<<K2/2<<"]="<<-y2<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"Y["<<K2/2<<":,"<<K2/2<<":]="<<y1<<"*identity_matrix(GF("<<F.cardinality()<<"),"<<K2/2<<");"<<std::endl;
-            // std::cerr<<"S1 = (A21-A11)*Y; S2 = A22-A21*Y;"<<std::endl;
-            // WriteMatrix(std::cerr<<"S1v = ",F, N2, K2, T, ldt, FflasSageMath);
-            // WriteMatrix(std::cerr<<"S2v = ",F, N2, K2, S2, lds, FflasSageMath);
-            // std::cerr<<"if (S1v != S1):"<<std::endl
-            //          <<"    print S1; print S1v"<<std::endl
-            //          <<"else:"<<std::endl
-            //          <<"    print ('S1 = S1v')"<<std::endl;
-            // std::cerr<<"if (S2v != S2):"<<std::endl
-            //          <<"    print S2;print S2v"<<std::endl
-            //          <<"else:"<<std::endl
-            //          <<"    print ('S2 = S2v')"<<std::endl;
 
                 // Up(C11) = Low(C22) (saving C22)
             if (uplo == FflasLower)

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -403,7 +403,8 @@ namespace FFLAS {
                 S1 = fflas_new(F, N2, K2);
                 S2 = fflas_new(F, N2, K2);
                 S4 = S1;
-                lds = K2;
+                if (trans==FflasNoTrans) lds = K2;
+                else  lds = N2;
             } else{
                 S1 = C21;
                 S2 = C12;
@@ -535,11 +536,12 @@ namespace FFLAS {
             F.init (negbeta);
             F.neg (negbeta, beta);
             typename Field::Element_ptr T = fflas_new (F, N2, std::max(N2,K2));
-            size_t ldt = std::max(N2,K2);
+            size_t ldt = (trans == FflasNoTrans)?std::max(N2,K2) : N2;
 
             if (K>N){ // Not possible to store S2 in C12
                 S2 = fflas_new(F, N2, K2);
-                lds = K2;
+                if (trans == FflasNoTrans) lds = K2;
+                else lds = N2;
             } else{
                 S2 = C12;
                 lds = ldc;

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -296,6 +296,8 @@ namespace FFLAS {
         if (WH.recLevel == 0){
             MMHelper<Field, MMHelperAlgo::Classic, FieldTrait>  CH(WH);
             fsyrk (F, uplo, trans, N, K, alpha, A, lda, beta, C, ldc,CH);
+            WH.Outmin = CH.Outmin;
+            WH.Outmax = CH.Outmax;
             return C;
         }
 
@@ -375,6 +377,7 @@ namespace FFLAS {
 
                 // P1 = A11 x A11^T in C11
             MMH_t H1 (F, WH.recLevel-1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
+            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"A11 = "<<std::endl, F, N2, K2, A11, lda);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A11, lda, F.zero, C11, ldc, H1);
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P1 = "<<std::endl, F, N2, N2, C11, ldc);
 
@@ -384,6 +387,7 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
                 freduce(F,N2,N2,C11,ldc);
             }
+           // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"after reduce P1 = "<<std::endl, F, N2, N2, C11, ldc);
             faddin (DF, uplo, N2, C11, ldc, C12, ldc); // TODO triangular addin (to be implemented)
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
 
@@ -434,7 +438,7 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C11, ldc);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U3 = "<<std::endl, F, N2, N2, C11, ldc);
+           // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U3 = "<<std::endl, F, N2, N2, C11, ldc);
                 // Updating WH with Outmin, Outmax of the result
             WH.Outmin = min3 (U3Min, U4Min, U5Min);
             WH.Outmax = max3 (U3Max, U4Max, U5Max);

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -364,7 +364,11 @@ namespace FFLAS {
             //std::cerr<<"x = "<<y1<< " y = "<<y2<<std::endl;
                 //  P4^T =  S2 x S1^T in  C22
             MMH_t H4 (F, -1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
-            fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S2, lds, S1, lds, F.zero, C22, ldc, H4);
+            if (uplo == FflasLower)
+                fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S2, lds, S1, lds, F.zero, C22, ldc, H4);
+            else
+                fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S1, lds, S2, lds, F.zero, C22, ldc, H4);
+                
             // std::cerr<<"alpha = "<<alpha<<std::endl;
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P4^T = "<<std::endl, F, N2, N2, C22, ldc);
 
@@ -385,8 +389,12 @@ namespace FFLAS {
 
                 // P3 = A22 x S4^T in C21
             MMH_t H3 (F, WH.recLevel-1, WH.Amin, WH.Amax, 2*WH.Bmin-WH.Bmax, 2*WH.Bmax-WH.Bmin, 0,0);
-            fgemm (F, trans, OppTrans, N2, N2, K2, alpha, A22, lda, S4, lds, F.zero, C21, ldc, H3);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P3 = "<<std::endl, F, N2, N2, C21, ldc);
+            if (uplo == FflasLower)
+                fgemm (F, trans, OppTrans, N2, N2, K2, alpha, A22, lda, S4, lds, F.zero, C21, ldc, H3);
+            else
+                fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S4, lds, A22, lda, F.zero, C21, ldc, H3);
+
+// WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P3 = "<<std::endl, F, N2, N2, C21, ldc);
 
             if (K>N){ fflas_delete(S1); }
 
@@ -407,8 +415,12 @@ namespace FFLAS {
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // make U1 explicit: Up(U1)=Low(U1)^T
-            for (size_t i=0; i<N2; i++)
-                fassign(F, i, C12+i*ldc, 1, C12+i, ldc);
+            if (uplo == FflasLower)
+                for (size_t i=0; i<N2; i++)
+                    fassign(F, i, C12+i*ldc, 1, C12+i, ldc);
+            else
+                for (size_t i=0; i<N2; i++)
+                    fassign(F, i, C12+i, ldc, C12+i*ldc, 1);
             // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U2 = U1 + P4 in C12

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -110,6 +110,7 @@ namespace FFLAS {
         typename Field::Element negy;
         F.init(negy);
         F.neg(negy, y);
+            // @todo: handle the case where y==0 (-1 is a square in the field
         for (size_t i=0; i<N2; i++, A11+=lda, A21+=lda, A22+=lda, A11r+=lda, A21r+=lda, A22r+=lda, S+=lds, Sr+=lds, T+=ldt, Tr+=ldt){
                 // @todo: vectorize this inner loop
             for (size_t j=0; j<K4; j++){

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -200,7 +200,7 @@ namespace FFLAS {
         return C;
     }
 
-        // Assumes that 2^reclevel divides N and K
+        // Assumes that 2^(reclevel+1) divides N and K
     template<class Field>
     inline typename Field::Element_ptr
     fsyrk_strassen (const Field& F,

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -85,9 +85,11 @@ namespace FFLAS{ namespace Protected{
     // x is assumed to be reduced
     {
         if (x<0){
+            // std::cerr<<"x<0"<<std::endl;
             if (Op2min < (WH.MaxStorableValue - Op1max) / x ||
                 Op2max > (-WH.MaxStorableValue - Op1min) / x ){
                 Outmin = WH.FieldMin + x * WH.FieldMax ;
+                // std::cerr<<"Outmin ("<<Outmin<<") =  WH.FieldMin ("<<WH.FieldMin<<") + x ("<<x<<") * WH.FieldMax"<<std::endl;
                 Outmax = WH.FieldMax + x * WH.FieldMin;
                 Op1min = WH.FieldMin;
                 Op1max = WH.FieldMax;
@@ -100,6 +102,7 @@ namespace FFLAS{ namespace Protected{
                 return false;
             }
         } else {
+            // std::cerr<<"x ("<<x<<") >0"<<std::endl;
             if (Op2max > (WH.MaxStorableValue - Op1max) / x ||
                 Op2min < (-WH.MaxStorableValue - Op1min) / x ){
                 Outmin = (x+1) * WH.FieldMin ;
@@ -156,7 +159,7 @@ namespace FFLAS {
         const typename MMH_t::DelayedField & DF = WH.delayedField;
         typedef typename  MMH_t::DelayedField::Element DFElt;
 
-//        std::cerr<<"COMPUTES1S2: A21min = "<<WH.Bmin<<" A21max = "<<WH.Bmax<<" A11min = "<<WH.Amin<<" A11max = "<<WH.Amax<<std::endl;
+        // std::cerr<<"#COMPUTES1S2: A21min = "<<WH.Bmin<<" A21max = "<<WH.Bmax<<" A11min = "<<WH.Amin<<" A11max = "<<WH.Amax<<std::endl;
         size_t N2 = N>>1;
         size_t K2 = K>>1;
         size_t K4 = K2>>1;
@@ -207,7 +210,7 @@ namespace FFLAS {
         if (Protected::NeedPreScalReduction (S1min, S1max, WH.Bmin, WH.Bmax, x, WH)){
             reduceA21 = true;
         }
-        // std::cerr<<"reduceA21 = "<<reduceA21<<" S1min = "<<S1min<<" S1max = "<<S1max<<std::endl;
+        // std::cerr<<"#reduceA21 = "<<reduceA21<<" S1min = "<<S1min<<" S1max = "<<S1max<<std::endl;
         bool reduceS1 = false;
         if (y){
             bool redS1 = Protected::NeedPreAxpyReduction (S2min, S2max, S1min, S1max, WH.Bmin, WH.Bmax, y, WH);
@@ -222,14 +225,14 @@ namespace FFLAS {
             S2min = S1min;
             S2max = S1max;
         }
-        // std::cerr<<"reduceS1 = "<<reduceS1<<" S2min = "<<S2min<<" S2max = "<<S2max<<std::endl;
+        // std::cerr<<"#reduceS1 = "<<reduceS1<<" S2min = "<<S2min<<" S2max = "<<S2max<<std::endl;
         bool reduceS2 = false;
         bool reduceA11 = false;
         if (Protected::NeedPreAxpyReduction (S3min, S3max, S2min, S2max, WH.Amin, WH.Amax, negx, WH)){
             reduceS2 = true;
             reduceA11 = true;
         }
-        // std::cerr<<"reduceS2 = "<<reduceS2<<" S3min = "<<S3min<<" S3max = "<<S3max<<std::endl;
+        // std::cerr<<"#reduceS2 = "<<reduceS2<<" S3min = "<<S3min<<" S3max = "<<S3max<<std::endl;
 
         
         bool reduceS3 = false;
@@ -246,7 +249,7 @@ namespace FFLAS {
             Smin = S3min;
             Smax = S3max;
         }
-        // std::cerr<<"reduceS3 = "<<reduceS2<<" Smin = "<<Smin<<" Smax = "<<Smax<<std::endl;
+        // std::cerr<<"#reduceS3 = "<<reduceS3<<" Smin = "<<Smin<<" Smax = "<<Smax<<std::endl;
         bool reduceA22 = false;
         if (Protected::NeedPreSubReduction (Tmin, Tmax, WH.Cmin, WH.Cmax, S2min, S2max, WH)) {
             reduceA22 = true;
@@ -306,10 +309,10 @@ namespace FFLAS {
                 if (!F.isZero(y)){
                     faxpy (DF, N2, negy, A21r, 1, S, 1);
                     faxpy (DF, N2, y, A21, 1, Sr, 1);
-                    if (reduceS2){
-                        freduce(F, N2, S, 1);
-                        freduce(F, N2, Sr, 1);
-                    }
+                }
+                if (reduceS2){
+                    freduce(F, N2, S, 1);
+                    freduce(F, N2, Sr, 1);
                 }
                     // T <- A22 -S
                 if (reduceA22 && reduceS2){

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -226,61 +226,88 @@ namespace FFLAS {
             typename Field::Element_ptr T = fflas_new (F, N2, std::max(N2,K2));
             size_t ldt = std::max(N2,K2);
 
-                // S2 = A22 - A21 x Y^T in C12
                 // S1 = (A11-A21) x Y^T in T1
-            computeS1S2 (F, N2, K2, y1, y2, A, lda, C12, ldc, T, ldt);
+                // S2 = A22 - A21 x Y^T in C12
+            computeS1S2 (F, N, K, y1, y2, A, lda, T, ldt, C12, ldc);
+            WriteMatrix(std::cerr<<"S1 = "<<std::endl, F, N2, K2, T, ldt);
+            WriteMatrix(std::cerr<<"S2 = "<<std::endl, F, N2, K2, C12, ldc);
 
                 // Up(C11) = Low(C22) (saving C22)
             for (size_t i=0; i<N2-1; ++i)
                 fassign (F, N2-i-1, C22 + (N2-i-1)*ldc, 1, C11 + 1 + i*(ldc+1), 1);
 
+                // temp for storing the diagonal of C22
+            typename Field::Element_ptr DC22 = fflas_new(F,N2);
+            for (size_t i=0; i<N2; ++i)
+                F.assign (DC22[i], C22[i*(ldc+1)]);
+
+            WriteMatrix(std::cerr<<"Up(C11) = Low(C22) = "<<std::endl, F, N2, N2, C11, ldc);
+
                 // - P4^T = - S2 x S1^T in C22
             fgemm (F, trans, OppTrans, N2, N2, K2, negalpha, C12, ldc, T, ldt, F.zero, C22, ldc);
 
+            WriteMatrix(std::cerr<<"-P4 = "<<std::endl, F, N2, N2, C22, ldc);
 
-                // S3 = S1 + A22 in T1
+                // S3 = S1 + A22 in T
             faddin (F, N2, K2, A22, lda, T, ldt);
+            WriteMatrix(std::cerr<<"S3 = "<<std::endl, F, N2, K2, T, ldt);
 
                 // P5 = S3 x S3^T in C12
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, T, ldt, F.zero, C12, ldc, reclevel-1);
+            WriteMatrix(std::cerr<<"P5 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // S4 = S3 - A12 in T1
             fsubin (F, N2, K2, A12, lda, T, ldt);
+            WriteMatrix(std::cerr<<"S4 = "<<std::endl, F, N2, K2, T, ldt);
 
-                // - P3 = - A22 x S4^T -  beta C21 in C21
-            fgemm (F, trans, OppTrans, N2, N2, K2, negalpha, A22, lda, T, ldt, negbeta, C21, ldc);
+                // - P3 = - A22 x S4^T + beta C21 in C21
+            fgemm (F, trans, OppTrans, N2, N2, K2, negalpha, A22, lda, T, ldt, beta, C21, ldc);
+            WriteMatrix(std::cerr<<"-P3 = "<<std::endl, F, N2, N2, C21, ldc);
 
                 // P1 = A11 x A11^T in T1
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A11, lda, F.zero, T, ldt, reclevel-1);
+            WriteMatrix(std::cerr<<"P1 = "<<std::endl, F, N2, N2, T, ldt);
 
                 // P2 = A12 x A12^T + beta C11 in C11
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A12, lda, beta, C11, ldc, reclevel-1);
-
+            WriteMatrix(std::cerr<<"P2 = "<<std::endl, F, N2, N2, C11, ldc);
                 // U3 = P1 + P2 in C11
             faddin (F, uplo, N2, T, ldt, C11, ldc);
-
-            fflas_delete (T);
+            WriteMatrix(std::cerr<<"U3 = "<<std::endl, F, N2, N2, C11, ldc);
 
                 // U1 = P5 + P1  in C12 // Still symmetric
             faddin (F, uplo, N2, T, ldt, C12, ldc);
+            WriteMatrix(std::cerr<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
+
+            fflas_delete (T);
 
                 // Make U1 explicit (copy the N/2 missing part)
             for (size_t i=0; i<N2; ++i)
                 fassign (F, i, C12 + i*ldc, 1, C12 + i, ldc);
+            WriteMatrix(std::cerr<<"U1 explicit = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U2 = U1 - P4 in C12
             for (size_t i=0; i<N2; i++)
                 faddin (F, N2, C22 + i*ldc, 1, C12 + i, ldc);
+            WriteMatrix(std::cerr<<"U2 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U4 = U2 - P3 in C21
             faddin (F, N2, N2, C12, ldc, C21, ldc);
+            WriteMatrix(std::cerr<<"U4 = "<<std::endl, F, N2, N2, C21, ldc);
 
                 // U5 = U2 - P4^T + beta Up(C11)^T in C22 (only the lower triang part)
             faddin (F, uplo, N2, C12, ldc, C22, ldc);
-            for (size_t i=1; i<N2; i++){ // TODO factorize out in a triple add
-                faxpy (F, i, beta, C11 + (N-i)*(ldc+1), 1, C22+i*ldc, 1);
+            WriteMatrix(std::cerr<<"U5 sans acc = "<<std::endl, F, N2, N2, C22, ldc);
+            for (size_t i=0; i<N2-1; i++){ // TODO factorize out in a triple add
+                faxpy (F, N2-i-1, beta, C11 + 1+i*(ldc+1), 1, C22 + (N2-i-1)*ldc, 1);
+                F.axpyin (C22[i*(ldc+1)], beta, DC22[i]);
             }
+            F.axpyin (C22[(N2-1)*(ldc+1)], beta, DC22[N2-1]);
+            WriteMatrix(std::cerr<<"U5 = "<<std::endl, F, N2, N2, C22, ldc);
+
+            fflas_delete(DC22);
         }
+        WriteMatrix(std::cerr<<"C = "<<std::endl, F, N, N, C, ldc);
         return C;
     }
 //============================

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -268,7 +268,11 @@ namespace FFLAS {
         fsyrk_strassen (F, UpLo, trans, Ns, Ks, y1, y2, alpha, A, lda, beta, C, ldc, H);
 
             // C11 += A12 x A12 ^T
-        fsyrk (F, UpLo, trans, Ns, K-Ks, alpha, A12, lda, F.one, C, ldc);
+        MMHelper<Field, MMHelperAlgo::Classic, Mode>  H2 (H);
+        H2.Cmin = H.Outmin;
+        H2.Cmax = H.Outmax;
+
+        fsyrk (F, UpLo, trans, Ns, K-Ks, alpha, A12, lda, F.one, C, ldc, H2);
 
             // C22 = [A21 A22] x [A21 A22]^T
         fsyrk (F, UpLo, trans, N-Ns, K, alpha, A21, lda, beta, C+Ns*(ldc+1), ldc);
@@ -580,6 +584,7 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C22, ldc);
+            freduce(F,N2,N2,C22,ldc);
 
                 // U5' = U5 +  beta Up(C11)^T in C22
                 // TODO use delayed field and a needPreAXPYReduction

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -30,59 +30,6 @@
 
 namespace FFLAS {
 
-    // template<class Field>
-    // inline void
-    // S1S2quadrant (const Field& F,
-    //               const size_t N,
-    //               const size_t K,
-    //               const typename Field::Element x,
-    //               typename Field::ConstElement_ptr A, const size_t lda,
-    //               typename Field::Element_ptr S, const size_t lds,
-    //               typename Field::Element_ptr T, const size_t ldt){
-
-    //     typename Field::ConstElement_ptr A11=A;
-    //     typename Field::ConstElement_ptr A21=A+N*lda;
-    //     typename Field::ConstElement_ptr A22=A21+K;
-
-    //     size_t N2 = N>>1;
-    //     size_t K2 = K>>1;
-    //     for (size_t i=0; i<N2; i++, A11+=lda, A21+=lda, A22+=lda, S+=lds, T+=ldt){
-    //             // @todo: vectorize this inner loop
-    //         for (size_t j=0; j<K2; j++){
-    //             typename Field::Element t;
-    //             F.init(t);
-    //             F.sub(t,A11[j],A21[j]);
-    //             F.mul(S[j],t,x);
-    //             F.maxpy(T[j], A21[j], x, A22[j]);
-    //         }
-    //     }
-    // }
-
-    // template<class Field>
-    // inline void
-    // computeS1S2 (const Field& F,
-    //              const size_t N,
-    //              const size_t K,
-    //              const typename Field::Element x,
-    //              const typename Field::Element y,
-    //              typename Field::ConstElement_ptr A, const size_t lda,
-    //              typename Field::Element_ptr S, const size_t lds,
-    //              typename Field::Element_ptr T, const size_t ldt){
-    //         // S1 = (A11-A21) x Y^T in S
-    //         // S2 = A22 - A21 x Y^T in T
-    //         // where Y = [ x.I  y.I]
-    //         //           [ -y.I x.I]
-    //     size_t N2 = N>>1;
-    //     typename Field::Element negy;
-    //     F.init(negy);
-    //     F.neg(negy, y);
-    //     S1S2quadrant (F, N, K, x, A, lda, S, lds, T, ldt);
-    //     S1S2quadrant (F, N, K, negy, A+N2, lda, S+N2, lds, T+N2, ldt);
-    //     S1S2quadrant (F, N, K, y, A+N2*lda, lda, S+N2*lds, lds, T+N2*ldt, ldt);
-    //     S1S2quadrant (F, N, K, x, A+N2*lda+N2, lda, S+N2*lds+N2, lds, T+N2*ldt+N2, ldt);
-    // }
-    //     ///////////
-    
     template<class Field, class FieldTrait>
     inline void
     computeS1S2 (const Field& F,
@@ -100,7 +47,6 @@ namespace FFLAS {
             // where Y = [ x.I  y.I]
             //           [ -y.I x.I]
         typedef MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait > MMH_t;
-            //typedef typename  MMH_t::DelayedField::Element DFElt;
         const typename MMH_t::DelayedField & DF = WH.delayedField;
 
         size_t N2 = N>>1;
@@ -132,25 +78,6 @@ namespace FFLAS {
         F.neg(negx, x);
         F.init(negy);
         F.neg(negy, y); 
-        //     // T <-  A21 Y^T
-        // fscal (F, N2, K2, x, A21, lda, T, ldt);
-        // if (!F.isZero(y)){
-        //     faxpy (F, N2, K4, y, A21r, lda, T, ldt);
-        //     faxpy (F, N2, K4, negy, A21, lda, Tr, ldt);
-        // }
-        //     // S <- T + A11 Y^T
-        //     // introduce a faxpy with 4 operands
-        //       //  S <- A11 Y^T
-        // fscal (F, N2, K2, x, A11, lda, S, lds);
-        // if (!F.isZero(y)){
-        //     faxpy (F, N2, K4, y, A11r, lda, S, lds);
-        //     faxpy (F, N2, K4, negy, A11, lda, Sr, lds);
-        // }
-        //     // S <- S - T
-        // fsubin (F, N2, K2, T, ldt, S, lds);
-
-        //     // T <- T - A22
-        // fsubin (F, N2, K2, A22, lda, T, ldt);
 
         if (trans==FflasNoTrans){
             F.assign(y1, y);
@@ -208,34 +135,6 @@ namespace FFLAS {
             }
             
         }
-        // } else { // -1 is not a square in F
-//         size_t K4 = K2>>1;
-//         typename Field::ConstElement_ptr A11r = A11 + K4;
-//             typename Field::ConstElement_ptr A21r = A21 + K4;
-//             typename Field::ConstElement_ptr A22r = A22 + K4;
-//             typename Field::Element_ptr Sr = S + K4;
-//             typename Field::Element_ptr Tr = T + K4;
-//             for (size_t i=0; i<N2; i++, A11+=lda, A21+=lda, A22+=lda, A11r+=lda, A21r+=lda, A22r+=lda, S+=lds, Sr+=lds, T+=ldt, Tr+=ldt){
-//                     // @todo: vectorize this inner loop
-//                 for (size_t j=0; j<K4; j++){
-//                     typename Field::Element t, tr;
-//                     F.init(t);
-//                     F.init(tr);
-//                     F.sub(t,A11[j],A21[j]);
-//                     F.sub(tr,A11r[j],A21r[j]);
-//                     F.mul(S[j],t,x);
-//                     F.mul(Sr[j],t,negy);
-//                     F.axpyin(S[j],tr,y);
-//                     F.axpyin(Sr[j],tr,x);
-
-//                     F.maxpy(T[j], A21[j], x, A22[j]);
-//                     F.maxpy(Tr[j], A21[j], negy, A22r[j]);
-
-//                     F.maxpyin(T[j], A21r[j], y);
-//                     F.maxpyin(Tr[j], A21r[j], x);
-//                 }
-//             }
-//         }
     }
 
     template<class Field>
@@ -250,7 +149,6 @@ namespace FFLAS {
            const typename Field::Element beta,
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Winograd,  ModeCategories::DelayedTag, ParSeqHelper::Sequential> & H){
-            //std::cerr<<"fsyrk Wino Delayed"<<std::endl;
         if (!N) return C;
         if (!K || F.isZero(alpha)){
             fscalin (F, N, N, beta, C, ldc); // TODO UpLo
@@ -267,8 +165,6 @@ namespace FFLAS {
             F.assign (beta_,beta);
         }
         MMHelper<Field, MMHelperAlgo::Winograd, ModeCategories::LazyTag>  HD(H);
-        // std::cerr<<"\n Delayed -> Lazy alpha_ = "<<alpha_<<std::endl;
-        //std::cerr<<" A = "<<*A<<"\n B = "<<*B<<"\n C = "<<*C<<"\n alpha, beta ="<<alpha<<" "<<beta<<std::endl;
 
         fsyrk(F, UpLo, trans, N, K, alpha_, A, lda, beta_, C, ldc, HD);
 
@@ -292,8 +188,7 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc,
            MMHelper<Field, MMHelperAlgo::Winograd, Mode> & H){
 
-            //std::cerr<<"Wino Mode, n quelconque"<<std::endl;
-        size_t q = 1 << (H.recLevel+1); // 
+        size_t q = 1 << (H.recLevel+1);
         size_t Ns = (N/q)*q;
         size_t Ks = (K/q)*q;
         
@@ -321,9 +216,7 @@ namespace FFLAS {
         MMHelper<Field, MMHelperAlgo::Classic, Mode>  H2 (H);
         H2.Cmin = H.Outmin;
         H2.Cmax = H.Outmax;
-            //WriteMatrix (std::cerr<<"---------------"<<std::endl<<"C11_strassen = "<<std::endl, F, Ns, Ns, C, ldc);
         fsyrk (F, UpLo, trans, Ns, K-Ks, alpha, A12, lda, F.one, C, ldc, H2);
-            //WriteMatrix (std::cerr<<"---------------"<<std::endl<<"C11++_strassen = "<<std::endl, F, Ns, Ns, C, ldc);
 
             // C22 = [A21 A22] x [A21 A22]^T
         fsyrk (F, UpLo, trans, N-Ns, K, alpha, A21, lda, beta, C+Ns*(ldc+1), ldc);
@@ -354,10 +247,7 @@ namespace FFLAS {
                     typename Field::Element_ptr C, const size_t ldc,
                     MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait> & WH
                     ) {
-        // std::cerr<<"Entree fsyrk_strassen"
-        //          <<" WH = "<<WH
-        //          <<std::endl;
-            // written for NoTrans, Lower
+            // Comments are written for the NoTrans, Lower version
         if (WH.recLevel == 0){
             MMHelper<Field, MMHelperAlgo::Classic, FieldTrait>  CH(WH);
             fsyrk (F, uplo, trans, N, K, alpha, A, lda, beta, C, ldc,CH);
@@ -367,8 +257,6 @@ namespace FFLAS {
         }
 
         typedef MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait > MMH_t;
-            //       typedef typename  MMH_t::DelayedField::Element_ptr DFEptr;
-            //       typedef typename  MMH_t::DelayedField::ConstElement_ptr DFCEptr;
         typedef typename  MMH_t::DelayedField::Element DFElt;
 
         const typename MMH_t::DelayedField & DF = WH.delayedField;
@@ -414,35 +302,25 @@ namespace FFLAS {
                 // S1 = (A21-A11) x Y in S1 (C21)
                 // S2 =  A22 - A21 x Y  in S2 (C12)
             computeS1S2 (F, trans, N, K, y1, y2, A,lda, S1, lds, S2, lds, WH);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"A21 = "<<std::endl, F, N2, K2, A21, lda);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"A11 = "<<std::endl, F, N2, K2, A11, lda);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S1 = "<<std::endl, F, N2, K2, C21, ldc);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S2 = "<<std::endl, F, N2, K2, C12, ldc);
-            //std::cerr<<"x = "<<y1<< " y = "<<y2<<std::endl;
+
                 //  P4^T =  S2 x S1^T in  C22
             MMH_t H4 (F, -1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
             if (uplo == FflasLower)
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S2, lds, S1, lds, F.zero, C22, ldc, H4);
             else
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S1, lds, S2, lds, F.zero, C22, ldc, H4);
-                
-            // std::cerr<<"alpha = "<<alpha<<std::endl;
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P4^T = "<<std::endl, F, N2, N2, C22, ldc);
 
             if (K>N){ fflas_delete(S2); }
 
                 // S3 = S1 - A22 in S1
             fsubin (DF, Arows, Acols, A22, lda, S1, lds);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S3 = "<<std::endl, F, N2, K2, S1, lds);
 
                 // P5 = S3 x S3^T in C12
             MMH_t H5 (F, WH.recLevel-1, 2*WH.Amin, 2*WH.Amax, 2*WH.Bmin, 2*WH.Bmax, 0,0);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, S1, lds, F.zero, C12, ldc, H5);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P5 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // S4 = S3 + A12 in S4
             fadd (DF, Arows, Acols, S1, lds, A12, lda, S4, lds);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"S4 = "<<std::endl, F, N2, K2, S4, lds);
 
                 // P3 = A22 x S4^T in C21
             MMH_t H3 (F, WH.recLevel-1, WH.Amin, WH.Amax, 2*WH.Bmin-WH.Bmax, 2*WH.Bmax-WH.Bmin, 0,0);
@@ -455,15 +333,12 @@ namespace FFLAS {
                 H3.Bmax = WH.Amax;
                 fgemm (F, trans, OppTrans, N2, N2, K2, alpha, S4, lds, A22, lda, F.zero, C21, ldc, H3);
             }
-// WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P3 = "<<std::endl, F, N2, N2, C21, ldc);
 
             if (K>N){ fflas_delete(S1); }
 
                 // P1 = A11 x A11^T in C11
             MMH_t H1 (F, WH.recLevel-1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"A11 = "<<std::endl, F, N2, K2, A11, lda);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A11, lda, F.zero, C11, ldc, H1);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P1 = "<<std::endl, F, N2, N2, C11, ldc);
 
                 // U1 = P1 + P5 in C12
             DFElt U1Min, U1Max;
@@ -471,9 +346,7 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
                 freduce(F,N2,N2,C11,ldc);
             }
-           // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"after reduce P1 = "<<std::endl, F, N2, N2, C11, ldc);
-            faddin (DF, uplo, N2, C11, ldc, C12, ldc); // TODO triangular addin (to be implemented)
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
+            faddin (DF, uplo, N2, C11, ldc, C12, ldc);
 
                 // make U1 explicit: Up(U1)=Low(U1)^T
             if (uplo == FflasLower)
@@ -482,7 +355,6 @@ namespace FFLAS {
             else
                 for (size_t i=0; i<N2; i++)
                     fassign(F, i, C12+i, ldc, C12+i*ldc, 1);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U1 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U2 = U1 + P4 in C12
             DFElt U2Min, U2Max;
@@ -492,9 +364,7 @@ namespace FFLAS {
             }
             for (size_t i=0; i<N2; ++i){
                 faddin (DF,  N2, C22+i*ldc, 1, C12+i, ldc);
-                // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"WIP U2 = "<<std::endl, F, N2, N2, C12, ldc);
             }
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U2 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U4 = U2 + P3 in C21
             DFElt U4Min, U4Max;
@@ -503,7 +373,6 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
             }
             faddin (DF, N2, N2, C12, ldc, C21, ldc);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U4 = "<<std::endl, F, N2, N2, C21, ldc);
 
                 // U5 = U2 + P4^T in C22
             DFElt U5Min, U5Max;
@@ -512,12 +381,10 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C22, ldc);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U5 = "<<std::endl, F, N2, N2, C22, ldc);
 
                 // P2 = A12 x A12^T in C12
             MMH_t H2 (F, WH.recLevel-1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0,0);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A12, lda, F.zero , C12, ldc, H2);
-            // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P2 = "<<std::endl, F, N2, N2, C12, ldc);
 
                 // U3 = P1 + P2 in C11
             DFElt U3Min, U3Max;
@@ -526,7 +393,6 @@ namespace FFLAS {
                 freduce(F,N2,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C11, ldc);
-           // WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U3 = "<<std::endl, F, N2, N2, C11, ldc);
                 // Updating WH with Outmin, Outmax of the result
             WH.Outmin = min3 (U3Min, U4Min, U5Min);
             WH.Outmax = max3 (U3Max, U4Max, U5Max);
@@ -596,7 +462,6 @@ namespace FFLAS {
                 // P1 = A11 x A11^T in T1
             MMH_t H1 (F, WH.recLevel-1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, 0, 0);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A11, lda, F.zero, T, ldt, H1);
-                //WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P1 = "<<std::endl, F, N2, N2, T, ldt);
 
                 // U1 = P5 + P1  in C12 // Still symmetric
             DFElt U1Min, U1Max;
@@ -606,7 +471,7 @@ namespace FFLAS {
            }
             faddin (DF, uplo, N2, T, ldt, C12, ldc);
 
-                // Make U1 explicit (copy the N/2 missing part)
+                // Make U1 explicit (copy the N^2/2 missing part)
             if (uplo == FflasLower)
                 for (size_t i=0; i<N2; ++i)
                     fassign (DF, i, C12 + i*ldc, 1, C12 + i, ldc);
@@ -661,7 +526,6 @@ namespace FFLAS {
                 // P2 = A12 x A12^T + beta C11 in C11
             MMH_t H2 (F, WH.recLevel-1, WH.Amin, WH.Amax, WH.Bmin, WH.Bmax, WH.Cmin, WH.Cmax);
             fsyrk_strassen (F, uplo, trans, N2, K2, y1, y2, alpha, A12, lda, beta, C11, ldc, H2);
-                //WriteMatrix (std::cerr<<"---------------"<<std::endl<<"P2 = "<<std::endl, F, N2, N2, C11, ldc);
 
                 // U3 = P1 + P2 in C11
             DFElt U3Min, U3Max;
@@ -670,7 +534,6 @@ namespace FFLAS {
                 freduce(F,N2,N2,T,ldt);
             }
             faddin (DF, uplo, N2, T, ldt, C11, ldc);
-                //WriteMatrix (std::cerr<<"---------------"<<std::endl<<"U3 = "<<std::endl, F, N2, N2, C11, ldc);
 
             fflas_delete (T);
             WH.Outmin = min3 (U3Min, U4Min, U5Min);
@@ -678,102 +541,6 @@ namespace FFLAS {
         }
          return C;
     }
-//============================
-            // version with accumulation and 3 temps
-            // S1 = A11 - A21 in C12
-
-            // A22' = A22 Y in T1
-
-            // S2 = A21 + A22' in T2
-
-            // P4 = S1 x S2^T in  T3
-
-            // P1 = A11 x A11^T in C12
-
-            // C11 = P1 + beta.C11 in C11
-        
-            // U3 = P2 + P1 = A12 x A12^T + P1 in C11
-
-            // S3 = A11 - S2 in T2
-        
-            // U1 = P1 - P5 = -S3 x S3^T + P1 in C12
-
-            // U2 = U1 - P4 in C12
-
-            // U5 = U2 - P4^T + C22 in C22 (add)
-
-            // S4 = S3  + A12 x Y in T2
-            // A12xY on the fly
-
-            // - P3 = - A22 Y x S4^T + C21 in C21
-
-            // U4 = U2 - P3  in C21
-
-////////////////////////////
-            // version without accumulation but requires 1 temp
-
-
-        
-            // S1 = A11 - A21 in C12
-
-            // A22' = A22 Y in C11
-
-            // S2 = A21 + A22' in C21
-
-            // P4 = S1 x S2^T in  C22
-
-            // S3 = A11 - S2 in C21
-
-            // -P5 = -S3 x S3^T  in T
-
-            // S4 = S3 x Y + A12 in C12
-
-            // -P3 = -A22' x S4^T in C21
-
-            // P1 = A11 x A11^T in C11
-
-            // U1 = P1 - P5 in T
-
-            // U2 = U1 - P4 in T
-
-            // U4 = U2 - P3 in C21
-
-            // U5 = U2 - P4^T in C22
-        
-            // P2 = A12 x A12^T in C12
-
-            // U3 = P1 + P2 in C11
-
-//        ======================
-            // algo du papier sans acc mais pas en place
-            // S1 = A11 - A21
-
-            // S2 = A21 + A22 x Y^T
-
-            // S3 = A11 - S2
-
-            // S4 = S3 x Y + A12
-
-            // P1 = A11 x A11^T in C11
-
-            // P2 = A12 x A12^T
-
-            // P3 = A22 Y x S4^T
-
-            // P4 = S1 x S2^T
-
-            // P5 = S3 x S3^T
-
-            // U1 = P1 - P5
-
-            // U2 = U1 - P4
-
-            // U3 = P1 + P2 in C11
-
-            // U4 = U2 - P3 in C21
-
-            // U5 = U2 - P4^T in C22
-        
 }
 
 

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -189,8 +189,9 @@ namespace FFLAS {
                     faxpy (DF, N2, y, A21, 1, Sr, 1);
                 }
                     // T <- A22 -S
+
                 fsub (DF, N2, A22, 1, S, 1, T, 1);
-                fsub (DF, N2, A22r, 1, S, 1, Tr, 1);
+                fsub (DF, N2, A22r, 1, Sr, 1, Tr, 1);
                 
                     // S <- S - A11 Y^T
                 faxpy (DF, N2, negx, A11, 1, S, 1);
@@ -267,7 +268,7 @@ namespace FFLAS {
         }
         MMHelper<Field, MMHelperAlgo::Winograd, ModeCategories::LazyTag>  HD(H);
         // std::cerr<<"\n Delayed -> Lazy alpha_ = "<<alpha_<<std::endl;
-        // std::cerr<<" A = "<<*A<<"\n B = "<<*B<<"\n C = "<<*C<<"\n alpha, beta ="<<alpha<<" "<<beta<<std::endl;
+        //std::cerr<<" A = "<<*A<<"\n B = "<<*B<<"\n C = "<<*C<<"\n alpha, beta ="<<alpha<<" "<<beta<<std::endl;
 
         fsyrk(F, UpLo, trans, N, K, alpha_, A, lda, beta_, C, ldc, HD);
 

--- a/fflas-ffpack/fflas/fflas_helpers.inl
+++ b/fflas-ffpack/fflas/fflas_helpers.inl
@@ -187,9 +187,7 @@ namespace FFLAS {
             * std::max(static_cast<const DFElt&>(-Bmin), Bmax);
             if ((diff < DFElt(0u))||(AB<DFElt(0u))) return 0;
 
-
             DFElt kmax = diff/AB;
-            std::cerr<<"diff = "<<diff<<" AB = "<<AB<<"kmax = "<<kmax<<std::endl;
             return FFLAS::Protected::min_types<DFElt>(kmax);
             // if (kmax > std::numeric_limits<size_t>::max())
             // 	return std::numeric_limits<size_t>::max();

--- a/fflas-ffpack/fflas/fflas_helpers.inl
+++ b/fflas-ffpack/fflas/fflas_helpers.inl
@@ -189,6 +189,7 @@ namespace FFLAS {
 
 
             DFElt kmax = diff/AB;
+            std::cerr<<"diff = "<<diff<<" AB = "<<AB<<"kmax = "<<kmax<<std::endl;
             return FFLAS::Protected::min_types<DFElt>(kmax);
             // if (kmax > std::numeric_limits<size_t>::max())
             // 	return std::numeric_limits<size_t>::max();

--- a/fflas-ffpack/fflas/fflas_helpers.inl
+++ b/fflas-ffpack/fflas/fflas_helpers.inl
@@ -258,6 +258,28 @@ namespace FFLAS {
 #endif
             return true;
         }
+        bool checkOut(const Field& F, FFLAS_UPLO uplo, const size_t M, const size_t N,
+                      typename Field::ConstElement_ptr A, const size_t lda ){
+#ifdef __FFLASFFPACK_DEBUG
+            if (uplo == FflasUpper){
+                for (size_t i=0; i<M;++i)
+                    for (size_t j=i; j<N;++j)
+                        if ((A[i*lda+j]>Outmax) || (A[i*lda+j]<Outmin)){
+                            std::cerr<<"Error in "<<Outmin<<" <= Out["<<i<<", "<<j<<"] = "<<A[i*lda+j]<<" <= "<<Outmax<<std::endl;
+                            return false;
+                        }
+            } else {
+                for (size_t i=0; i<M;++i)
+                    for (size_t j=0; j<=i;++j)
+                        if ((A[i*lda+j]>Outmax) || (A[i*lda+j]<Outmin)){
+                            std::cerr<<"Error in "<<Outmin<<" <= Out["<<i<<", "<<j<<"] = "<<A[i*lda+j]<<" <= "<<Outmax<<std::endl;
+                            return false;
+                        }
+
+            }
+#endif
+            return true;
+        }
 
         MMHelper(){}
         //TODO: delayedField constructor has a >0 characteristic even when it is a Double/FloatDomain

--- a/fflas-ffpack/fflas/fflas_helpers.inl
+++ b/fflas-ffpack/fflas/fflas_helpers.inl
@@ -76,6 +76,7 @@ namespace FFLAS {
     namespace MMHelperAlgo{
         struct Auto{};
         struct Classic{};
+        struct DivideAndConquer{};
         struct Winograd{};
         struct WinogradPar{};
         struct Bini{};

--- a/fflas-ffpack/fflas/fflas_level2.inl
+++ b/fflas-ffpack/fflas/fflas_level2.inl
@@ -456,6 +456,15 @@ namespace FFLAS {
             typename Field::ConstElement_ptr B, const size_t ldb,
             typename Field::Element_ptr C, const size_t ldc);
 
+    //! fadding for symmetric matrices
+    template <class Field>
+    void
+    faddin (const Field& F,
+            const FFLAS_UPLO uplo,
+            const size_t N,
+            typename Field::ConstElement_ptr B, const size_t ldb,
+            typename Field::Element_ptr C, const size_t ldc);
+
 
     /**  @brief finite prime Field GEneral Matrix Vector multiplication.
      *

--- a/fflas-ffpack/fflas/fflas_level3.inl
+++ b/fflas-ffpack/fflas/fflas_level3.inl
@@ -265,7 +265,7 @@ namespace FFLAS {
            const typename Field::Element beta,
            typename Field::Element_ptr C, const size_t ldc);
 
-    template<class Field>
+    template<class Field, FieldTrait>
     inline typename Field::Element_ptr
     fsyrk_strassen (const Field& F,
                     const FFLAS_UPLO UpLo,
@@ -278,7 +278,7 @@ namespace FFLAS {
                     typename Field::ConstElement_ptr A, const size_t lda,
                     const typename Field::Element beta,
                     typename Field::Element_ptr C, const size_t ldc,
-                    size_t reclevel /*todo: use helper instead*/);
+                    MMHelper<Field, MMHelperAlgo::Winograd, FieldTrait> & H);
 
     template<class Field>
     typename Field::Element_ptr

--- a/fflas-ffpack/fflas/fflas_level3.inl
+++ b/fflas-ffpack/fflas/fflas_level3.inl
@@ -265,7 +265,7 @@ namespace FFLAS {
            const typename Field::Element beta,
            typename Field::Element_ptr C, const size_t ldc);
 
-    template<class Field, FieldTrait>
+    template<class Field, typename  FieldTrait>
     inline typename Field::Element_ptr
     fsyrk_strassen (const Field& F,
                     const FFLAS_UPLO UpLo,

--- a/fflas-ffpack/fflas/fflas_level3.inl
+++ b/fflas-ffpack/fflas/fflas_level3.inl
@@ -266,6 +266,21 @@ namespace FFLAS {
            typename Field::Element_ptr C, const size_t ldc);
 
     template<class Field>
+    inline typename Field::Element_ptr
+    fsyrk_strassen (const Field& F,
+                    const FFLAS_UPLO UpLo,
+                    const FFLAS_TRANSPOSE trans,
+                    const size_t N,
+                    const size_t K,
+                    const typename Field::Element y1,
+                    const typename Field::Element y2,
+                    const typename Field::Element alpha,
+                    typename Field::ConstElement_ptr A, const size_t lda,
+                    const typename Field::Element beta,
+                    typename Field::Element_ptr C, const size_t ldc,
+                    size_t reclevel /*todo: use helper instead*/);
+
+    template<class Field>
     typename Field::Element_ptr
     fsyr2k (const Field& F,
             const FFLAS_UPLO UpLo,

--- a/fflas-ffpack/field/field-traits.h
+++ b/fflas-ffpack/field/field-traits.h
@@ -169,6 +169,7 @@ namespace FFLAS { /*  Traits */
 
     template <typename Element, typename Compute>
     struct ModeTraits<Givaro::Modular<Element,Compute> >{typedef typename ModeCategories::DelayedTag value;};
+    template<> struct ModeTraits<Givaro::Modular<int64_t,uint64_t> > {typedef typename ModeCategories::DefaultTag value;};
 
     template<typename Compute> struct ModeTraits<Givaro::Modular<int8_t,Compute> > {typedef typename ModeCategories::ConvertTo<ElementCategories::MachineFloatTag> value;};
     template<typename Compute> struct ModeTraits<Givaro::Modular<int16_t,Compute> > {typedef typename ModeCategories::ConvertTo<ElementCategories::MachineFloatTag> value;};

--- a/fflas-ffpack/utils/test-utils.h
+++ b/fflas-ffpack/utils/test-utils.h
@@ -65,8 +65,8 @@ namespace FFPACK {
         Givaro::Integer maxV= maxFieldElt<Field>();
             // For the moment, Modular<intXX_t> returns a maxcard which does not always allow compute products over the Storage_t which is assumed to be possible in many place in fflas-ffpack.
             // Reducing the maxcard consequently:
-        if (std::is_same<Field,Givaro::Modular<int64_t>>::value) maxV = 3037000500;
-        if (std::is_same<Field,Givaro::Modular<int32_t>>::value) maxV = 46341;
+        if (std::is_same<Field,Givaro::Modular<int64_t>>::value) maxV = 3037000500; // floor(2^31.5) such that ab+c  fits in int64_t with abs(a,b,c,d) <= (p-1)
+        if (std::is_same<Field,Givaro::Modular<int32_t>>::value) maxV = 46341; // floor(2^15.5) such that ab+c  fits in int32_t with abs(a,b,c,d) <= (p-1)
             //auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
         std::mt19937 mt_rand(seed);
         Givaro::Integer::seeding(mt_rand());

--- a/fflas-ffpack/utils/test-utils.h
+++ b/fflas-ffpack/utils/test-utils.h
@@ -63,7 +63,11 @@ namespace FFPACK {
     template<typename Field>
     Field* chooseField(Givaro::Integer q, uint64_t b, uint64_t seed){
         Givaro::Integer maxV= maxFieldElt<Field>();
-        //auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+            // For the moment, Modular<intXX_t> returns a maxcard which does not always allow compute products over the Storage_t which is assumed to be possible in many place in fflas-ffpack.
+            // Reducing the maxcard consequently:
+        if (std::is_same<Field,Givaro::Modular<int64_t>>::value) maxV = 3037000500;
+        if (std::is_same<Field,Givaro::Modular<int32_t>>::value) maxV = 46341;
+            //auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
         std::mt19937 mt_rand(seed);
         Givaro::Integer::seeding(mt_rand());
         if (maxV>0 && (q> maxV || b> maxV.bitsize()))

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -202,7 +202,7 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
     }
     if (!ok){
         std::cerr<<"Scaling failed"<<std::endl;
-        FFLAS::fflas_delete(A, B, C, C2, D);
+        fflas_delete(A, B, C, C2, D);
         return ok;
     }
 
@@ -226,30 +226,30 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
     else
         cout << "FAILED ("<<time<<")"<<endl;
 
-    FFLAS::fflas_delete(A);
-    FFLAS::fflas_delete(B);
-    FFLAS::fflas_delete(C2);
-    FFLAS::fflas_delete(C);
-    FFLAS::fflas_delete(D);
+    fflas_delete(A);
+    fflas_delete(B);
+    fflas_delete(C2);
+    fflas_delete(C);
+    fflas_delete(D);
     return ok;
 }
 template<typename Field, class RandIter>
 bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
                          const typename Field::Element &alpha, const typename Field::Element &beta,
-                         FFLAS::FFLAS_UPLO uplo, FFLAS::FFLAS_TRANSPOSE trans, RandIter& Rand){
+                         FFLAS_UPLO uplo, FFLAS_TRANSPOSE trans, RandIter& Rand){
 
     typedef typename Field::Element Element;
     Element * A, *B, *C, *C2, *D;
     size_t ldc = n+(rand()%50);
-    size_t Arows = (trans==FFLAS::FflasNoTrans)?n:k;
-    size_t Acols = (trans==FFLAS::FflasNoTrans)?k:n;
+    size_t Arows = (trans==FflasNoTrans)?n:k;
+    size_t Acols = (trans==FflasNoTrans)?k:n;
     size_t lda = Acols+(rand()%50);
     size_t incD = 1+(rand()%100);
-    A  = FFLAS::fflas_new(F,Arows,lda);
-    B  = FFLAS::fflas_new(F,Arows,lda);
-    C  = FFLAS::fflas_new(F,n,ldc);
-    C2  = FFLAS::fflas_new(F,n,ldc);
-    D  = FFLAS::fflas_new(F,k,incD);
+    A  = fflas_new(F,Arows,lda);
+    B  = fflas_new(F,Arows,lda);
+    C  = fflas_new(F,n,ldc);
+    C2  = fflas_new(F,n,ldc);
+    D  = fflas_new(F,k,incD);
     Givaro::GeneralRingNonZeroRandIter<Field,RandIter> nzRand (Rand);
     std::vector<bool> tb(k,false);
     for (size_t i=0; i<k; i++){
@@ -265,10 +265,10 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
 
     FFPACK::RandomTriangularMatrix (F, n, n, uplo, FflasNonUnit, true, C, ldc, Rand);
     FFPACK::RandomMatrix (F, Arows, Acols, A, lda, Rand);
-    FFLAS::fassign (F, n, n, C, ldc, C2, ldc);
-    FFLAS::fassign (F, Arows, Acols, A, lda, B, lda);
+    fassign (F, n, n, C, ldc, C2, ldc);
+    fassign (F, Arows, Acols, A, lda, B, lda);
 
-    string ss=string((uplo == FFLAS::FflasLower)?"Lower_":"Upper_")+string((trans == FFLAS::FflasTrans)?"Trans":"NoTrans");
+    string ss=string((uplo == FflasLower)?"Lower_":"Upper_")+string((trans == FflasTrans)?"Trans":"NoTrans");
 
     cout<<std::left<<"Checking FSYRK_BK_DIAG_";
     cout.fill('.');
@@ -276,10 +276,10 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
     cout<<ss;
 
 
-    // FFLAS::WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    // FFLAS::WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
-    // FFLAS::WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
-    FFLAS::Timer t; t.clear();
+    // WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    // WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
+    // WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
+    Timer t; t.clear();
     double time=0.0;
     t.clear(); t.start();
 
@@ -289,8 +289,8 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
     time+=t.usertime();
 
     // std::cerr<<"After fsyrk_bk_diag"<<std::endl;
-    // FFLAS::WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    // FFLAS::WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
+    // WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    // WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
     bool ok = true;
 
     typename Field::Element tmp;
@@ -328,7 +328,7 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
         std::cerr<<"Scaling failed"<<std::endl;
         std::cerr<<"alpha = "<<alpha<<" beta="<<beta<<std::endl;
         std::cerr<<"tb = "<<tb<<std::endl;
-        FFLAS::fflas_delete(A, B, C, C2, D);
+        fflas_delete(A, B, C, C2, D);
         return ok;
     }
 
@@ -356,11 +356,91 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
         cout << "FAILED ("<<time<<")"<<endl;
     //cerr<<"FAILED ("<<time<<")"<<endl;
 
-    FFLAS::fflas_delete(A);
-    FFLAS::fflas_delete(B);
-    FFLAS::fflas_delete(C2);
-    FFLAS::fflas_delete(C);
-    FFLAS::fflas_delete(D);
+    fflas_delete(A);
+    fflas_delete(B);
+    fflas_delete(C2);
+    fflas_delete(C);
+    fflas_delete(D);
+    return ok;
+}
+
+template <class Field, class RandIter>
+bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE trans, RandIter& G){
+
+    bool ok = true;
+    typename Field::Element_ptr A, S, T;
+    size_t STrows = 2*((trans==FflasNoTrans)?N:K);
+    size_t STcols = 2*((trans==FflasNoTrans)?K:N);
+    size_t Arows = 4*STrows;
+    size_t Acols = 4*STcols;
+    size_t lda = Acols+(rand()%50);
+    size_t lds = STcols+(rand()%50);
+    size_t ldt = STcols+(rand()%50);
+    A  = fflas_new(F,Arows,lda);
+    S  = fflas_new(F,STrows,lds);
+    T  = fflas_new(F,STrows,ldt);
+
+    FFPACK::RandomMatrix (F, Arows, Acols, A, lda, G);
+
+    MMHelper<Field, MMHelperAlgo::Winograd> WH(F,1);
+    Givaro::Integer a,b;
+    Givaro::IntSqrtModDom<> ISM;
+    Givaro::ZRing<Givaro::Integer> Z;
+    Z.init(a);
+    Z.init(b);
+    ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
+    typename Field::Element y1, y2;
+    F.init (y1, a);
+    F.init (y2, b);
+
+    computeS1S2 (F, trans, 4*N, 4*K, y1, y2, A, lda, S, lds, T, ldt, WH); 
+
+    if (trans==FflasNoTrans){
+        typename Field::Element_ptr V, Y, W;
+        typename Field::Element_ptr A21 = A + 2*N*lda;
+        typename Field::Element_ptr A22 = A21 + 2*K;
+        size_t ldv = STcols;
+        size_t ldw = STcols;
+        size_t ldy = STcols;
+        V  = fflas_new (F, STrows, ldv);
+        Y  = fflas_new (F, STcols, ldy);
+        W  = fflas_new (F, STrows, ldw);
+        for (size_t i=0; i<STcols; ++i){
+            for (size_t j=0; j<STcols; ++j){
+                F.assign(Y[i*ldy+j], F.zero);
+            }
+            F.assign (Y [i*ldy+i], y1);
+            if (i < K)
+                F.assign (Y [i*ldy + K + i], y2);
+            else
+                F.neg (Y [i*ldy + i - K], y2);
+        }
+            // W <- A21 - A11
+        fsub (F, STrows, STcols, A21, lda, A, lda, W, ldw);
+            // S < W x Y
+        fgemm (F, FflasNoTrans, FflasNoTrans, STrows, STcols, STcols, F.one, W, ldw, Y, ldy, F.zero, V, ldv);
+
+        if (!fequal (F, STrows, STcols, S, lds, V, ldv)){
+            std::cerr<< "FAILED: computing S"<<std::endl;
+            ok = false;
+        }
+
+            // W <- -A21 x Y
+        fgemm (F, FflasNoTrans, FflasNoTrans, STrows, STcols, STcols, F.mOne, A21, lda, Y, ldy, F.zero, W, ldw);
+            // V <- A22 + W
+        fadd (F, STrows, STcols, A22, lda, W, ldw, V, ldv);
+
+        if (!fequal (F, STrows, STcols, T, ldt, V, ldv)){
+            std::cerr<< "FAILED: computing T"<<std::endl;
+            ok = false;
+        }
+        
+        fflas_delete(A,S,T,V,W,Y);
+    
+    } else { // Trans
+        
+//        fflas_delete(A,S,T,V,W,Y);
+    }
     return ok;
 }
 
@@ -408,6 +488,9 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
         ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+
+        ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
+//        ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
         nbit--;
         delete F;
     }

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -448,10 +448,10 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-            //ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -521,31 +521,31 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         cout<<"Checking with ";F->write(cout)<<endl;
 
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-            // checking with k > n (=k+n)
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        //     // checking with k > n (=k+n)
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
 
             // Checking the preadditions with the skew othogonal matrix
         ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
@@ -590,10 +590,10 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         // conversion to RNS basis not available yet for fsyrk

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -394,10 +394,10 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+            //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -105,8 +105,8 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         //std::cerr<<std::endl<<std::endl;
     if (uplo == FflasUpper){
         for (size_t i=0; i<n; i++){
-            for (size_t j=0;j<i;j++)
-                    //std::cerr<<" ";
+            //for (size_t j=0;j<i;j++)
+            //        std::cerr<<" ";
             for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
                     //if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
@@ -462,11 +462,8 @@ int main(int argc, char** argv)
         ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
-            //ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,w,a,c,iters,seed);
-            //ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
-
         // conversion to RNS basis not available yet for fsyrk
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,(b?b:512),n/4+1,k/4+1,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -85,9 +85,9 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     F.init (y2, b);
 
     std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
-    WriteMatrix(std::cerr, F, n, k, A, lda);
+//    WriteMatrix(std::cerr, F, n, k, A, lda);
     
-    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 1);
+    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 2);
 
     t.stop();
     time+=t.usertime();

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -82,13 +82,13 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     // typename Field::Element y1, y2;
     // F.init (y1, a);
     // F.init (y2, b);
-
-        //  std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
+    //std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
             //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
-        //   <<std::endl;
-    WriteMatrix (std::cerr, F, n, k, A, lda);
-    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-     WriteMatrix (std::cerr, F, n, k, C, ldc);
+        //<<std::endl;
+    // WriteMatrix (std::cerr, F, n, k, A, lda);
+    // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+    // WriteMatrix (std::cerr, F, n, n, C, ldc);
+    // WriteMatrix(std::cerr, F, n, n, C, ldc,FflasSageMath );
     if (w == size_t(-1))
             //w= (rand() % 5);
         w=1;
@@ -97,7 +97,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
 
     t.stop();
     time+=t.usertime();
-    // WriteMatrix (std::cerr<<"Result C = "<<std::endl, F, n, n, C, ldc);
+        //WriteMatrix (std::cerr<<"Result C = "<<std::endl, F, n, n, C, ldc);
 
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 
@@ -106,26 +106,26 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     if (uplo == FflasUpper){
         for (size_t i=0; i<n; i++){
             for (size_t j=0;j<i;j++)
-                    // std::cerr<<" ";
+                    //std::cerr<<" ";
             for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                    std::cerr<<".";
-                else
-                    std::cerr<<"X";
+                    //if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                        //std::cerr<<".";
+                    //else
+                        //std::cerr<<"X";
             }
-            std::cerr<<std::endl;
+                //std::cerr<<std::endl;
         }
     } else {
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                    std::cerr<<".";
-                else
-                    std::cerr<<"X";
+                    //if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                        //std::cerr<<".";
+                    //else
+                        //std::cerr<<"X";
             }
-            std::cerr<<std::endl;
+                //std::cerr<<std::endl;
         }
     }
     if (ok)
@@ -394,7 +394,7 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-//        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
             //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
@@ -458,10 +458,10 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        // ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -83,7 +83,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     // F.init (y1, a);
     // F.init (y2, b);
     //std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
-            //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
+        //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
         //<<std::endl;
     // WriteMatrix (std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
@@ -120,12 +120,12 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                    if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                            std::cerr<<".";
-                    else
-                        std::cerr<<"X";
+                    // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                    //         std::cerr<<".";
+                    // else
+                    //     std::cerr<<"X";
             }
-            std::cerr<<std::endl;
+            // std::cerr<<std::endl;
         }
     }
     if (ok)
@@ -394,11 +394,11 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-            // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-            // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+            //ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -398,28 +398,28 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-            //ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-        // // checking with k > n (=k+n)
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+            // checking with k > n (=k+n)
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
         nbit--;
         delete F;
     }
@@ -462,10 +462,10 @@ int main(int argc, char** argv)
         ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
-        // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,a,c,iters,seed);
+            //ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,w,a,c,iters,seed);
+            //ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
 
         // conversion to RNS basis not available yet for fsyrk
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -78,7 +78,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     //     // find a, b such that a^2 + b^2 = -1 mod p
     // Givaro::Integer a,b;
     // Givaro::IntSqrtModDom<> ISM;
-    // ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
+    // ISM.sumofsquaresmodprime (a, b, -1, F.characteristic())h;
     // typename Field::Element y1, y2;
     // F.init (y1, a);
     // F.init (y2, b);
@@ -102,10 +102,20 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 
     bool ok = true;
+    std::cerr<<std::endl<<std::endl;
     if (uplo == FflasUpper){
-        for (size_t i=0; i<n; i++)
-            for (size_t j=i; j<n; j++)
+        for (size_t i=0; i<n; i++){
+            for (size_t j=0;j<i;j++)
+                std::cerr<<" ";
+            for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
+                // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                //     std::cerr<<".";
+                // else
+                //     std::cerr<<"X";
+            }
+                //         std::cerr<<std::endl;
+        }
     } else {
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
@@ -448,10 +458,10 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -75,23 +75,13 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     double time=0.0;
     t.clear(); t.start();
 
-    //     // find a, b such that a^2 + b^2 = -1 mod p
-    // Givaro::Integer a,b;
-    // Givaro::IntSqrtModDom<> ISM;
-    // ISM.sumofsquaresmodprime (a, b, -1, F.characteristic())h;
-    // typename Field::Element y1, y2;
-    // F.init (y1, a);
-    // F.init (y2, b);
-    //std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
-        //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
-        //<<std::endl;
     // WriteMatrix (std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
     // WriteMatrix (std::cerr, F, n, n, C, ldc);
     // WriteMatrix(std::cerr, F, n, n, C, ldc,FflasSageMath );
     if (w == size_t(-1))
-            //w= (rand() % 5);
-        w=1;
+        w= (rand() % 5);
+        
     MMHelper<Field, MMHelperAlgo::Winograd> H(F,w);
     fsyrk (F, uplo, trans, n, k, alpha, A, lda, beta, C, ldc, H);
 

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -378,8 +378,8 @@ bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE tran
     typename Field::Element_ptr A, S, T;
     size_t STrows = 2*((trans==FflasNoTrans)?N:K);
     size_t STcols = 2*((trans==FflasNoTrans)?K:N);
-    size_t Arows = 4*STrows;
-    size_t Acols = 4*STcols;
+    size_t Arows = 2*STrows;
+    size_t Acols = 2*STcols;
     size_t lda = Acols+(rand()%50);
     size_t lds = STcols+(rand()%50);
     size_t ldt = STcols+(rand()%50);
@@ -389,19 +389,31 @@ bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE tran
 
     FFPACK::RandomMatrix (F, Arows, Acols, A, lda, G);
 
-    MMHelper<Field, MMHelperAlgo::Winograd> WH(F,1);
+    MMHelper<Field, MMHelperAlgo::Winograd, ModeCategories::LazyTag> WH(F,1);
     Givaro::Integer a,b;
     Givaro::IntSqrtModDom<> ISM;
     Givaro::ZRing<Givaro::Integer> Z;
     Z.init(a);
     Z.init(b);
     ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
-    typename Field::Element y1, y2;
+    typename Field::Element y1, y2,negy2;
     F.init (y1, a);
     F.init (y2, b);
-
+    
+    F.neg(negy2,y2);
+    WriteMatrix(std::cerr<<"A = "<<std::endl, F, Arows, Acols, A, lda);
+    WriteMatrix(std::cerr<<"A = ", F, Arows, Acols, A, lda, FflasSageMath);
+    std::cerr<<"A11=A[:2,:2]; A21=A[2:,:2]; A12=A[:2,2:]; A22=A[2:,2:]; Y=Matrix(GF("
+             <<F.cardinality()<<"),"<<STrows<<","<<STcols<<",["<<y1<<","<<y2<<","<<negy2<<","<<y1<<"])"<<std::endl
+             <<"S = (A21-A11)*Y; T = A22 - A21*Y"<<std::endl;
+    std::cerr<<"y1, y2 = "<<y1<<" "<<y2<<std::endl;
+    
     computeS1S2 (F, trans, 4*N, 4*K, y1, y2, A, lda, S, lds, T, ldt, WH); 
 
+    WriteMatrix(std::cerr<<"S = "<<std::endl, F, STrows, STcols, S, lds);
+    WriteMatrix(std::cerr<<"T = "<<std::endl, F, STrows, STcols, T, ldt);
+
+    
     typename Field::Element_ptr V, Y, W;
     typename Field::Element_ptr A21, A22;
     size_t Ydim = 2*K;
@@ -457,7 +469,7 @@ bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE tran
     
     fflas_delete(A,S,T,V,W,Y);
     
-    cout << "PASSED"<<endl;
+    if (ok) cout << "PASSED"<<endl;
 
     return ok;
 }
@@ -480,35 +492,35 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-            // checking with k > n (=k+n)
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        //     // checking with k > n (=k+n)
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
 
         ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
-        ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
+        // ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
         nbit--;
         delete F;
     }
@@ -556,9 +568,10 @@ int main(int argc, char** argv)
         // conversion to RNS basis not available yet for fsyrk
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,(b?b:512),n/4+1,k/4+1,a,c,iters,seed);
+        seed++;
     } while (loop && ok);
 
-    if (!ok) std::cerr<<"with seed = "<<seed<<std::endl;
+    if (!ok) std::cerr<<"with seed = "<<seed-1<<std::endl;
 
     return !ok ;
 }

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -37,6 +37,7 @@
 #include "fflas-ffpack/utils/args-parser.h"
 #include "fflas-ffpack/utils/test-utils.h"
 #include <givaro/modular.h>
+#include <givaro/givintsqrootmod.h>
 
 
 using namespace std;
@@ -75,11 +76,18 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     double time=0.0;
     t.clear(); t.start();
 
-        // TODO: find y1, y2 using Brillhart alg in Givaro
+        // find a, b such that a^2 + b^2 = -1 mod p
+    Givaro::Integer a,b;
+    Givaro::IntSqrtModDom<> ISM;
+    ISM.sumofsquaresmodprime (a, b, -1, F.characteristic());
     typename Field::Element y1, y2;
-    F.init(y1, y2);
+    F.init (y1, a);
+    F.init (y2, b);
 
-    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 3);
+    std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
+    WriteMatrix(std::cerr, F, n, k, A, lda);
+    
+    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 1);
 
     t.stop();
     time+=t.usertime();
@@ -357,32 +365,32 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, int a, int
         F->init (beta, (typename Field::Element)c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-        // checking with k > n (=k+n)
-        ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // // checking with k > n (=k+n)
+        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
         nbit--;
         delete F;
     }
@@ -420,15 +428,15 @@ int main(int argc, char** argv)
     bool ok = true;
     do{
         ok = ok && run_with_field<Modular<double> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<Modular<float> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,a,c,iters,seed);
-        ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);
-        ok = ok && run_with_field<Modular<Givaro::Integer> >(q,(b?b:512),n/4+1,k/4+1,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<float> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);
+        // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,(b?b:512),n/4+1,k/4+1,a,c,iters,seed);
     } while (loop && ok);
 
     if (!ok) std::cerr<<"with seed = "<<seed<<std::endl;

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -83,10 +83,12 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     // F.init (y1, a);
     // F.init (y2, b);
 
-//    std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" and "<<a<<"^2 + "<<b<<"^2 = -1"<<std::endl;
-    // WriteMatrix(std::cerr, F, n, k, A, lda);
+    std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
+            //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
+             <<std::endl;
+    // WriteMatrix (std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-    //   WriteMatrix(std::cerr, F, n, k, C, ldc);
+//    WriteMatrix (std::cerr, F, n, k, C, ldc);
     if (w == size_t(-1))
             //w= (rand() % 5);
         w=1;
@@ -95,6 +97,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
 
     t.stop();
     time+=t.usertime();
+    // WriteMatrix (std::cerr, F, n, n, C, ldc);
 
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -102,11 +102,11 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 
     bool ok = true;
-    std::cerr<<std::endl<<std::endl;
+        //std::cerr<<std::endl<<std::endl;
     if (uplo == FflasUpper){
         for (size_t i=0; i<n; i++){
             for (size_t j=0;j<i;j++)
-                std::cerr<<" ";
+                // std::cerr<<" ";
             for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
                 // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
@@ -114,7 +114,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
                 // else
                 //     std::cerr<<"X";
             }
-                //         std::cerr<<std::endl;
+            // std::cerr<<std::endl;
         }
     } else {
         for (size_t i=0; i<n; i++){
@@ -125,7 +125,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
                 // else
                 //     std::cerr<<"X";
             }
-                //std::cerr<<std::endl;
+            // std::cerr<<std::endl;
         }
     }
     if (ok)

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -84,10 +84,10 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     F.init (y1, a);
     F.init (y2, b);
 
-    std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
-    WriteMatrix(std::cerr, F, n, k, A, lda);
-    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-      WriteMatrix(std::cerr, F, n, k, C, ldc);
+    // std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
+    // WriteMatrix(std::cerr, F, n, k, A, lda);
+    // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+    //   WriteMatrix(std::cerr, F, n, k, C, ldc);
   
     fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 1);
 

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -368,8 +368,6 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, int a, int
         typename Field::Element alpha, beta;
         F->init (alpha, a);
         F->init (beta, c);
-        std::cerr<<"a = "<<a<<" alpha = "<<alpha<<std::endl;
-        std::cerr<<"b = "<<c<<" beta = "<<beta<<std::endl;
         cout<<"Checking with ";F->write(cout)<<endl;
 
         // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -25,6 +25,8 @@
 
 #define ENABLE_ALL_CHECKINGS 1
 
+//#define DEBUG_TRACE
+
 #include "fflas-ffpack/fflas-ffpack-config.h"
 
 #include <iomanip>
@@ -75,10 +77,12 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     double time=0.0;
     t.clear(); t.start();
 
-    // WriteMatrix (std::cerr, F, n, k, A, lda);
-    // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-    // WriteMatrix (std::cerr, F, n, n, C, ldc);
-    // WriteMatrix(std::cerr, F, n, n, C, ldc,FflasSageMath );
+#ifdef DEBUG_TRACE
+    WriteMatrix (std::cerr, F, n, k, A, lda);
+    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+    WriteMatrix (std::cerr, F, n, n, C, ldc);
+    WriteMatrix(std::cerr, F, n, n, C, ldc,FflasSageMath );
+#endif
     if (w == size_t(-1))
         w= (rand() % 5);
         
@@ -87,39 +91,53 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
 
     t.stop();
     time+=t.usertime();
-        //WriteMatrix (std::cerr<<"Result C = "<<std::endl, F, n, n, C, ldc);
-
+#ifdef DEBUG_TRACE
+    WriteMatrix (std::cerr<<"Result C = "<<std::endl, F, n, n, C, ldc);
+#endif
+    
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 
     bool ok = true;
-        //std::cerr<<std::endl<<std::endl;
+#ifdef DEBUG_TRACE
+    std::cerr<<std::endl<<std::endl;
+#endif
     if (uplo == FflasUpper){
         for (size_t i=0; i<n; i++){
-            //for (size_t j=0;j<i;j++)
-            //        std::cerr<<" ";
+#ifdef DEBUG_TRACE
+            for (size_t j=0;j<i;j++)
+                std::cerr<<" ";
+#endif
             for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                    //if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                        //std::cerr<<".";
-                    //else
-                        //std::cerr<<"X";
+#ifdef DEBUG_TRACE
+                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                    std::cerr<<".";
+                else
+                    std::cerr<<"X";
+#endif
             }
-                //std::cerr<<std::endl;
+#ifdef DEBUG_TRACE
+            std::cerr<<std::endl;
+#endif
         }
     } else {
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                    // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                    //         std::cerr<<".";
-                    // else
-                    //     std::cerr<<"X";
+#ifdef DEBUG_TRACE
+                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                    std::cerr<<".";
+                else
+                    std::cerr<<"X";
+#endif
             }
-            // std::cerr<<std::endl;
+#ifdef DEBUG_TRACE
+            std::cerr<<std::endl;
+#endif
         }
     }
     if (ok)
-        //cout << "\033[1;32mPASSED\033[0m ("<<time<<")"<<endl;
+            //cout << "\033[1;32mPASSED\033[0m ("<<time<<")"<<endl;
         cout << "PASSED ("<<time<<")"<<endl;
     //cerr<<"PASSED ("<<time<<")"<<endl;
     else
@@ -165,9 +183,11 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
     cout<<ss;
 
 
-    // FFLAS::WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    // FFLAS::WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
-    // FFLAS::WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
+#ifdef DEBUG_TRACE
+    FFLAS::WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    FFLAS::WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
+    FFLAS::WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
+#endif
     FFLAS::Timer t; t.clear();
     double time=0.0;
     t.clear(); t.start();
@@ -177,10 +197,11 @@ bool check_fsyrk_diag (const Field &F, size_t n, size_t k,
     t.stop();
     time+=t.usertime();
 
-    // std::cerr<<"After fsyrk_diag"<<std::endl;
-    //  FFLAS::WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    //  FFLAS::WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
-
+#ifdef DEBUG_TRACE
+    std::cerr<<"After fsyrk_diag"<<std::endl;
+    FFLAS::WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    FFLAS::WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
+#endif
     bool ok = true;
 
     typename Field::Element tmp;
@@ -276,9 +297,11 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
     cout<<ss;
 
 
-    // WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    // WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
-    // WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
+#ifdef DEBUG_TRACE
+    WriteMatrix ( std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    WriteMatrix ( std::cerr<<"C = "<<std::endl,F,n,n, C, ldc);
+    WriteMatrix ( std::cerr<<"D = "<<std::endl,F,k,1,D, incD);
+#endif
     Timer t; t.clear();
     double time=0.0;
     t.clear(); t.start();
@@ -288,9 +311,11 @@ bool check_fsyrk_bkdiag (const Field &F, size_t n, size_t k,
     t.stop();
     time+=t.usertime();
 
-    // std::cerr<<"After fsyrk_bk_diag"<<std::endl;
-    // WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
-    // WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
+#ifdef DEBUG_TRACE
+    std::cerr<<"After fsyrk_bk_diag"<<std::endl;
+    WriteMatrix (std::cerr<<"A = "<<std::endl,F,Arows, Acols, A, lda);
+    WriteMatrix (std::cerr<<"C = "<<std::endl,F,n,n,C,ldc);
+#endif
     bool ok = true;
 
     typename Field::Element tmp;
@@ -401,18 +426,21 @@ bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE tran
     F.init (y2, b);
     
     F.neg(negy2,y2);
-    // WriteMatrix(std::cerr<<"A = "<<std::endl, F, Arows, Acols, A, lda);
-    // WriteMatrix(std::cerr<<"A = ", F, Arows, Acols, A, lda, FflasSageMath);
-    // std::cerr<<"A11=A[:2,:2]; A21=A[2:,:2]; A12=A[:2,2:]; A22=A[2:,2:]; Y=Matrix(GF("
-    //          <<F.cardinality()<<"),"<<STrows<<","<<STcols<<",["<<y1<<","<<y2<<","<<negy2<<","<<y1<<"])"<<std::endl
-    //          <<"S = (A21-A11)*Y; T = A22 - A21*Y"<<std::endl;
-    // std::cerr<<"y1, y2 = "<<y1<<" "<<y2<<std::endl;
-    
+#ifdef DEBUG_TRACE
+    WriteMatrix(std::cerr<<"A = "<<std::endl, F, Arows, Acols, A, lda);
+    WriteMatrix(std::cerr<<"A = ", F, Arows, Acols, A, lda, FflasSageMath);
+    std::cerr<<"A11=A[:2,:2]; A21=A[2:,:2]; A12=A[:2,2:]; A22=A[2:,2:]; Y=Matrix(GF("
+             <<F.cardinality()<<"),"<<STrows<<","<<STcols<<",["<<y1<<","<<y2<<","<<negy2
+             <<","<<y1<<"])"<<std::endl
+             <<"S = (A21-A11)*Y; T = A22 - A21*Y"<<std::endl;
+    std::cerr<<"y1, y2 = "<<y1<<" "<<y2<<std::endl;
+#endif
     computeS1S2 (F, trans, 4*N, 4*K, y1, y2, A, lda, S, lds, T, ldt, WH); 
 
-    // WriteMatrix(std::cerr<<"S = "<<std::endl, F, STrows, STcols, S, lds);
-    // WriteMatrix(std::cerr<<"T = "<<std::endl, F, STrows, STcols, T, ldt);
-
+#ifdef DEBUG_TRACE
+    WriteMatrix(std::cerr<<"S = "<<std::endl, F, STrows, STcols, S, lds);
+    WriteMatrix(std::cerr<<"T = "<<std::endl, F, STrows, STcols, T, ldt);
+#endif
     
     typename Field::Element_ptr V, Y, W;
     typename Field::Element_ptr A21, A22;
@@ -492,33 +520,34 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-        //     // checking with k > n (=k+n)
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+            // checking with k > n (=k+n)
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
 
+            // Checking the preadditions with the skew othogonal matrix
         ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
         ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
         nbit--;
@@ -529,8 +558,8 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
 
 int main(int argc, char** argv)
 {
-    cerr<<setprecision(17);
-    cout<<setprecision(17);
+    cerr<<setprecision(10);
+    cout<<setprecision(10);
 
     Givaro::Integer q=-1;
     size_t b=0;

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -361,9 +361,9 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, int a, int
         //typedef typename Field::Element Element ;
         // choose Field
         Field* F= FFPACK::chooseField<Field>(q,b,seed);
-        typename Field::RandIter G(*F,seed++);
         if (F==nullptr)
             return true;
+        typename Field::RandIter G(*F,seed++);
 
         typename Field::Element alpha, beta;
         F->init (alpha, a);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -85,9 +85,11 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     F.init (y2, b);
 
     std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
-//    WriteMatrix(std::cerr, F, n, k, A, lda);
-    
-    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 2);
+    WriteMatrix(std::cerr, F, n, k, A, lda);
+    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+      WriteMatrix(std::cerr, F, n, k, C, ldc);
+  
+    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 1);
 
     t.stop();
     time+=t.usertime();

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -401,17 +401,17 @@ bool check_computeS1S2 (const Field& F, size_t N, size_t K, FFLAS_TRANSPOSE tran
     F.init (y2, b);
     
     F.neg(negy2,y2);
-    WriteMatrix(std::cerr<<"A = "<<std::endl, F, Arows, Acols, A, lda);
-    WriteMatrix(std::cerr<<"A = ", F, Arows, Acols, A, lda, FflasSageMath);
-    std::cerr<<"A11=A[:2,:2]; A21=A[2:,:2]; A12=A[:2,2:]; A22=A[2:,2:]; Y=Matrix(GF("
-             <<F.cardinality()<<"),"<<STrows<<","<<STcols<<",["<<y1<<","<<y2<<","<<negy2<<","<<y1<<"])"<<std::endl
-             <<"S = (A21-A11)*Y; T = A22 - A21*Y"<<std::endl;
-    std::cerr<<"y1, y2 = "<<y1<<" "<<y2<<std::endl;
+    // WriteMatrix(std::cerr<<"A = "<<std::endl, F, Arows, Acols, A, lda);
+    // WriteMatrix(std::cerr<<"A = ", F, Arows, Acols, A, lda, FflasSageMath);
+    // std::cerr<<"A11=A[:2,:2]; A21=A[2:,:2]; A12=A[:2,2:]; A22=A[2:,2:]; Y=Matrix(GF("
+    //          <<F.cardinality()<<"),"<<STrows<<","<<STcols<<",["<<y1<<","<<y2<<","<<negy2<<","<<y1<<"])"<<std::endl
+    //          <<"S = (A21-A11)*Y; T = A22 - A21*Y"<<std::endl;
+    // std::cerr<<"y1, y2 = "<<y1<<" "<<y2<<std::endl;
     
     computeS1S2 (F, trans, 4*N, 4*K, y1, y2, A, lda, S, lds, T, ldt, WH); 
 
-    WriteMatrix(std::cerr<<"S = "<<std::endl, F, STrows, STcols, S, lds);
-    WriteMatrix(std::cerr<<"T = "<<std::endl, F, STrows, STcols, T, ldt);
+    // WriteMatrix(std::cerr<<"S = "<<std::endl, F, STrows, STcols, S, lds);
+    // WriteMatrix(std::cerr<<"T = "<<std::endl, F, STrows, STcols, T, ldt);
 
     
     typename Field::Element_ptr V, Y, W;
@@ -520,7 +520,7 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
 
         ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
-        // ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
+        ok = ok && check_computeS1S2(*F, n, k, FflasTrans, G);
         nbit--;
         delete F;
     }
@@ -529,7 +529,9 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
 
 int main(int argc, char** argv)
 {
-    cerr<<setprecision(10);
+    cerr<<setprecision(17);
+    cout<<setprecision(17);
+
     Givaro::Integer q=-1;
     size_t b=0;
     int k=125;
@@ -559,10 +561,10 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        // ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         // conversion to RNS basis not available yet for fsyrk

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -84,7 +84,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     F.init (y1, a);
     F.init (y2, b);
 
-    std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
+    std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" and "<<a<<"^2 + "<<b<<"^2 = -1"<<std::endl;
     // WriteMatrix(std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
     //   WriteMatrix(std::cerr, F, n, k, C, ldc);
@@ -363,8 +363,10 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, int a, int
             return true;
 
         typename Field::Element alpha, beta;
-        F->init (alpha, (typename Field::Element)a);
-        F->init (beta, (typename Field::Element)c);
+        F->init (alpha, a);
+        F->init (beta, c);
+        std::cerr<<"a = "<<a<<" alpha = "<<alpha<<std::endl;
+        std::cerr<<"b = "<<c<<" beta = "<<beta<<std::endl;
         cout<<"Checking with ";F->write(cout)<<endl;
 
         // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -384,32 +384,32 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+            //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
 
         // // checking with k > n (=k+n)
-        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_diag(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
         nbit--;
         delete F;
     }

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -137,8 +137,6 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         cout << "FAILED ("<<time<<")"<<endl;
     //cerr<<"FAILED ("<<time<<")"<<endl;
 
-    if (!ok){
-    }
     FFLAS::fflas_delete(A);
     FFLAS::fflas_delete(C2);
     FFLAS::fflas_delete(C);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -75,7 +75,11 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     double time=0.0;
     t.clear(); t.start();
 
-    fsyrk (F, uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+        // TODO: find y1, y2 using Brillhart alg in Givaro
+    typename Field::Element y1, y2;
+    F.init(y1, y2);
+
+    fsyrk_strassen (F, uplo, trans, n, k, y1, y2, alpha, A, lda, beta, C, ldc, 3);
 
     t.stop();
     time+=t.usertime();

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -83,12 +83,12 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     // F.init (y1, a);
     // F.init (y2, b);
 
-    std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
+        //  std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
             //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
-             <<std::endl;
+        //   <<std::endl;
     // WriteMatrix (std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-//    WriteMatrix (std::cerr, F, n, k, C, ldc);
+    // WriteMatrix (std::cerr, F, n, k, C, ldc);
     if (w == size_t(-1))
             //w= (rand() % 5);
         w=1;
@@ -97,7 +97,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
 
     t.stop();
     time+=t.usertime();
-    // WriteMatrix (std::cerr, F, n, n, C, ldc);
+    // WriteMatrix (std::cerr<<"Result C = "<<std::endl, F, n, n, C, ldc);
 
     fgemm (F, trans, (trans==FflasNoTrans)?FflasTrans:FflasNoTrans, n, n, k, alpha, A, lda, A, lda, beta, C2, ldc);
 
@@ -107,9 +107,16 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
             for (size_t j=i; j<n; j++)
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
     } else {
-        for (size_t i=0; i<n; i++)
-            for (size_t j=0; j<=i; j++)
+        for (size_t i=0; i<n; i++){
+            for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
+                // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                //     std::cerr<<".";
+                // else
+                //     std::cerr<<"X";
+            }
+                //std::cerr<<std::endl;
+        }
     }
     if (ok)
         //cout << "\033[1;32mPASSED\033[0m ("<<time<<")"<<endl;
@@ -120,6 +127,8 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         cout << "FAILED ("<<time<<")"<<endl;
     //cerr<<"FAILED ("<<time<<")"<<endl;
 
+    if (!ok){
+    }
     FFLAS::fflas_delete(A);
     FFLAS::fflas_delete(C2);
     FFLAS::fflas_delete(C);
@@ -439,9 +448,9 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+            //ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,a,c,iters,seed);
-        // ok = ok && run_with_field<Modular<float> >(q,b,n,k,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<int32_t> >(q,b,n,k,a,c,iters,seed);
         // ok = ok && run_with_field<ModularBalanced<int32_t> >(q,b,n,k,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -86,9 +86,9 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         //  std::cerr<<"Launching fsyrk_strassen with alpha = "<<alpha<<" beta = "<<beta<<" w = "<<w
             //<<" and "<<a<<"^2 + "<<b<<"^2 = -1"
         //   <<std::endl;
-    // WriteMatrix (std::cerr, F, n, k, A, lda);
-    // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
-    // WriteMatrix (std::cerr, F, n, k, C, ldc);
+    WriteMatrix (std::cerr, F, n, k, A, lda);
+    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+     WriteMatrix (std::cerr, F, n, k, C, ldc);
     if (w == size_t(-1))
             //w= (rand() % 5);
         w=1;
@@ -106,26 +106,26 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
     if (uplo == FflasUpper){
         for (size_t i=0; i<n; i++){
             for (size_t j=0;j<i;j++)
-                // std::cerr<<" ";
+                    // std::cerr<<" ";
             for (size_t j=i; j<n; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                //     std::cerr<<".";
-                // else
-                //     std::cerr<<"X";
+                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                    std::cerr<<".";
+                else
+                    std::cerr<<"X";
             }
-            // std::cerr<<std::endl;
+            std::cerr<<std::endl;
         }
     } else {
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                // if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                //     std::cerr<<".";
-                // else
-                //     std::cerr<<"X";
+                if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                    std::cerr<<".";
+                else
+                    std::cerr<<"X";
             }
-            // std::cerr<<std::endl;
+            std::cerr<<std::endl;
         }
     }
     if (ok)
@@ -394,7 +394,7 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+//        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
             //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -79,7 +79,10 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
 
 #ifdef DEBUG_TRACE
     WriteMatrix (std::cerr, F, n, k, A, lda);
-    WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
+    WriteMatrix(std::cerr<<"A=", F, n, k, A, lda,FflasSageMath );
+    std::cerr<<"A11=A[:"<<Arows/2<<",:"<<Acols/2
+             <<"]; A21=A["<<Arows/2<<":,:"<<Acols/2<<"]; A12=A[:"
+             <<Arows/2<<","<<Acols/2<<":]; A22=A["<<Arows/2<<":,"<<Acols/2<<":];"<<std::endl;
     WriteMatrix (std::cerr, F, n, n, C, ldc);
     WriteMatrix(std::cerr, F, n, n, C, ldc,FflasSageMath );
 #endif
@@ -521,31 +524,31 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         cout<<"Checking with ";F->write(cout)<<endl;
 
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k,alpha,beta,FflasLower,FflasTrans,G);
 
-        //     // checking with k > n (=k+n)
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
-        // ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+            // checking with k > n (=k+n)
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k+n,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_diag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasUpper,FflasTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk_bkdiag(*F,n,k+n,alpha,beta,FflasLower,FflasTrans,G);
 
             // Checking the preadditions with the skew othogonal matrix
         ok = ok && check_computeS1S2(*F, n, k, FflasNoTrans, G);
@@ -590,12 +593,12 @@ int main(int argc, char** argv)
     srand(seed);
     bool ok = true;
     do{
-        // ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<double> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<double> >(q,b,n,k,w,a,c,iters,seed);
         ok = ok && run_with_field<Modular<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
-        // ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<float> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<Modular<int64_t> >(q,b,n,k,w,a,c,iters,seed);
+        ok = ok && run_with_field<ModularBalanced<int64_t> >(q,b,n,k,w,a,c,iters,seed);
         // conversion to RNS basis not available yet for fsyrk
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,5,n/4+1,k/4+1,a,c,iters,seed);
         // ok = ok && run_with_field<Modular<Givaro::Integer> >(q,(b?b:512),n/4+1,k/4+1,a,c,iters,seed);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -394,10 +394,10 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+        // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-            //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -84,7 +84,7 @@ bool check_fsyrk (const Field &F, size_t n, size_t k,
     F.init (y1, a);
     F.init (y2, b);
 
-    // std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
+    std::cerr<<"Launching fsyrk_strassen with a = "<<a<<" b = "<<b<<" A = "<<std::endl;
     // WriteMatrix(std::cerr, F, n, k, A, lda);
     // WriteMatrix(std::cerr, F, n, k, A, lda,FflasSageMath );
     //   WriteMatrix(std::cerr, F, n, k, C, ldc);

--- a/tests/test-fsyrk.C
+++ b/tests/test-fsyrk.C
@@ -120,12 +120,12 @@ bool check_fsyrk (const Field &F, size_t n, size_t k, size_t w,
         for (size_t i=0; i<n; i++){
             for (size_t j=0; j<=i; j++){
                 ok = ok && F.areEqual(C2[i*ldc+j], C[i*ldc+j]);
-                    //if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
-                        //std::cerr<<".";
-                    //else
-                        //std::cerr<<"X";
+                    if (F.areEqual(C2[i*ldc+j], C[i*ldc+j]))
+                            std::cerr<<".";
+                    else
+                        std::cerr<<"X";
             }
-                //std::cerr<<std::endl;
+            std::cerr<<std::endl;
         }
     }
     if (ok)
@@ -394,10 +394,10 @@ bool run_with_field (Givaro::Integer q, size_t b, size_t n, size_t k, size_t w, 
         F->init (beta, c);
         cout<<"Checking with ";F->write(cout)<<endl;
 
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
+            // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
-        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
-            //ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
+            // ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);
+        ok = ok && check_fsyrk(*F,n,k,w,alpha,beta,FflasLower,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasNoTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasUpper,FflasTrans,G);
         // ok = ok && check_fsyrk_diag(*F,n,k,w,alpha,beta,FflasLower,FflasNoTrans,G);


### PR DESCRIPTION
This PR builds on top the branch of PR #295 . So either incrementally review and merge #295 and then consider this one or close #295 and only work on this massive diff!

The topic here is to use delayed modular reductions when computing the S1 and S2 matrices (additions and multiplication by the skew orthogonal matrix Y), as much as possible. 