### PR TITLE
Symmetric freduce

### DIFF
--- a/fflas-ffpack/fflas/fflas_freduce.h
+++ b/fflas-ffpack/fflas/fflas_freduce.h
@@ -151,17 +151,16 @@ namespace FFLAS {
     }
     template<class Field>
     void
-    freduce (const Field& F, const FFLAS_UPLO UpLo,
-             const size_t m , const size_t n,
+    freduce (const Field& F, const FFLAS_UPLO UpLo, const size_t N,
              typename Field::Element_ptr A, const size_t lda)
     {
-        assert(m<=n); // otherwise n-i or i+1 might go out of range
+        typename Field::Element_ptr Ai = A;
         if (UpLo == FflasUpper){
-            for (size_t i = 0 ; i < m ; ++i)
-                freduce (F, n-i, A+i*(lda+1), 1);
+            for (size_t i = N ; i > 0 ; --i, Ai+=lda+1)
+                freduce (F, i, Ai, 1);
         } else { // Lower
-            for (size_t i = 0 ; i < m ; ++i)
-                freduce (F, i+1, A+i*lda, 1);
+            for (size_t i = 1 ; i <= N ; ++i, Ai+=lda)
+                freduce (F, i, Ai, 1);
         }
         return;
     }

--- a/fflas-ffpack/fflas/fflas_fsyrk.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk.inl
@@ -200,8 +200,7 @@ namespace FFLAS {
 
     namespace Protected {
         template <class Field, class AlgoT, class ParSeqTrait>
-        inline void ScalAndReduce (const Field& F, const FFLAS_UPLO UpLo,
-                                   const size_t M, const size_t N,
+        inline void ScalAndReduce (const Field& F, const FFLAS_UPLO UpLo, const size_t N,
                                    const typename Field::Element alpha,
                                    typename Field::Element_ptr A, const size_t lda,
                                    const MMHelper<Field, AlgoT, ModeCategories::LazyTag, ParSeqTrait >& H)
@@ -211,14 +210,14 @@ namespace FFLAS {
                 F.convert(al, alpha);
                 if (al<0) al = -al;
                 if (std::max(-H.Outmin, H.Outmax) > H.MaxStorableValue/al){
-                    freduce (F, UpLo, M, N, A, lda);
-                    fscalin (F, M, N, alpha, A, lda);
+                    freduce (F, UpLo, N, A, lda);
+                    fscalin (F, N, N, alpha, A, lda);
                 } else {
-                    fscalin (H.delayedField, M, N, alpha, (typename MMHelper<Field, AlgoT, ModeCategories::LazyTag, ParSeqTrait >::DFElt*)A, lda);
-                    freduce (F, UpLo, M, N, A, lda);
+                    fscalin (H.delayedField, N, N, alpha, (typename MMHelper<Field, AlgoT, ModeCategories::LazyTag, ParSeqTrait >::DFElt*)A, lda);
+                    freduce (F, UpLo, N, A, lda);
                 }
             } else
-                freduce (F, UpLo, M, N, A, lda);
+                freduce (F, UpLo, N, A, lda);
         }
     }
 
@@ -254,7 +253,7 @@ namespace FFLAS {
 
         fsyrk (F, UpLo, trans, N, K, alpha_, A, lda, beta_, C, ldc, HD);
 
-        Protected::ScalAndReduce (F, UpLo, N, N, alpha, C, ldc, HD);
+        Protected::ScalAndReduce (F, UpLo, N, alpha, C, ldc, HD);
 
         H.initOut();
 
@@ -322,7 +321,7 @@ namespace FFLAS {
             }
             if (!F.isZero(beta) && (H.Cmin < H.FieldMin || H.Cmax>H.FieldMax)){
                 H.initC();
-                freduce (F, UpLo, N, N, C, ldc);
+                freduce (F, UpLo, N, C, ldc);
             }
             kmax = H.MaxDelayedDim (betadf);
         }
@@ -355,7 +354,7 @@ namespace FFLAS {
                betadf, (DFElt_ptr)C, ldc, Hfp);
 
         for (size_t i = 0; i < nblock; ++i) {
-            freduce (F, UpLo, N, N, C, ldc);
+            freduce (F, UpLo, N, C, ldc);
             Hfp.initC();
             fsyrk (H.delayedField, UpLo, trans, N, k2, alphadf,
                    (DFCElt_ptr)A +i*shiftA, lda,
@@ -369,7 +368,7 @@ namespace FFLAS {
             // getting -Outmin returns a int, not the same base type.
             if (std::max(static_cast<const decltype(Hfp.Outmin)&>(-Hfp.Outmin), Hfp.Outmax)
                 >Hfp.MaxStorableValue/al){
-                freduce (F, UpLo, N, N, C, ldc);
+                freduce (F, UpLo, N, C, ldc);
                 Hfp.initOut();
             }
 

--- a/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
+++ b/fflas-ffpack/fflas/fflas_fsyrk_strassen.inl
@@ -551,11 +551,17 @@ namespace FFLAS {
                 // U1 = P1 + P5 in C12
             DFElt U1Min, U1Max;
             if (Protected::NeedPreAddReduction (U1Min, U1Max, H1.Outmin, H1.Outmax, H5.Outmin, H5.Outmax, WH)){
-                freduce(F,N2,N2,C12,ldc);
-                freduce(F,N2,N2,C11,ldc);
+                freduce(F,uplo,N2,C12,ldc);
+                freduce(F,uplo,N2,C11,ldc);
             }
             faddin (DF, uplo, N2, C11, ldc, C12, ldc);
 
+                // U2 = U1 + P4 in C12
+            DFElt U2Min, U2Max;
+            if (Protected::NeedPreAddReduction (U2Min, U2Max, U1Min, U1Max, H4.Outmin, H4.Outmax, WH)){
+                freduce(F,uplo,N2,C12,ldc);
+                freduce(F,N2,N2,C22,ldc);
+            }
                 // make U1 explicit: Up(U1)=Low(U1)^T
             if (uplo == FflasLower)
                 for (size_t i=0; i<N2; i++)
@@ -564,12 +570,6 @@ namespace FFLAS {
                 for (size_t i=0; i<N2; i++)
                     fassign(F, i, C12+i, ldc, C12+i*ldc, 1);
 
-                // U2 = U1 + P4 in C12
-            DFElt U2Min, U2Max;
-            if (Protected::NeedPreAddReduction (U2Min, U2Max, U1Min, U1Max, H4.Outmin, H4.Outmax, WH)){
-                freduce(F,N2,N2,C12,ldc);
-                freduce(F,N2,N2,C22,ldc);
-            }
             for (size_t i=0; i<N2; ++i){
                 faddin (DF,  N2, C22+i*ldc, 1, C12+i, ldc);
             }
@@ -585,8 +585,8 @@ namespace FFLAS {
                 // U5 = U2 + P4^T in C22
             DFElt U5Min, U5Max;
             if (Protected::NeedPreAddReduction (U5Min, U5Max, U2Min, U2Max, H4.Outmin, H4.Outmax, WH)){
-                freduce(F,N2,N2,C22,ldc);
-                freduce(F,N2,N2,C12,ldc);
+                freduce(F,uplo,N2,C22,ldc);
+                freduce(F,uplo,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C22, ldc);
 
@@ -597,8 +597,8 @@ namespace FFLAS {
                 // U3 = P1 + P2 in C11
             DFElt U3Min, U3Max;
             if (Protected::NeedPreAddReduction (U3Min, U3Max, H1.Outmin, H1.Outmax, H2.Outmin, H2.Outmax, WH)){
-                freduce(F,N2,N2,C11,ldc);
-                freduce(F,N2,N2,C12,ldc);
+                freduce(F,uplo,N2,C11,ldc);
+                freduce(F,uplo,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C11, ldc);
                 // Updating WH with Outmin, Outmax of the result
@@ -678,11 +678,17 @@ namespace FFLAS {
                 // U1 = P5 + P1  in C12 // Still symmetric
             DFElt U1Min, U1Max;
             if (Protected::NeedPreAddReduction (U1Min, U1Max, H5.Outmin, H5.Outmax, H1.Outmin, H1.Outmax, WH)){
-                freduce(F,N2,N2,C12,ldc);
-                freduce(F,N2,N2,T,ldt);
+                freduce(F,uplo,N2,C12,ldc);
+                freduce(F,uplo,N2,T,ldt);
            }
             faddin (DF, uplo, N2, T, ldt, C12, ldc);
 
+                // U2 = U1 + P4 in C12
+            DFElt U2Min, U2Max;
+            if (Protected::NeedPreAddReduction (U2Min, U2Max, U1Min, U1Max, H4.Outmin, H4.Outmax, WH)){
+                freduce(F,uplo,N2,C12,ldc);
+                freduce(F,N2,N2,C22,ldc);
+            }
                 // Make U1 explicit (copy the N^2/2 missing part)
             if (uplo == FflasLower)
                 for (size_t i=0; i<N2; ++i)
@@ -691,12 +697,6 @@ namespace FFLAS {
                 for (size_t i=0; i<N2; ++i)
                     fassign (DF, i, C12 + i, ldc, C12 + i*ldc, 1);                
 
-                // U2 = U1 + P4 in C12
-            DFElt U2Min, U2Max;
-            if (Protected::NeedPreAddReduction (U2Min, U2Max, U1Min, U1Max, H4.Outmin, H4.Outmax, WH)){
-                freduce(F,N2,N2,C12,ldc);
-                freduce(F,N2,N2,C22,ldc);
-            }
             for (size_t i=0; i<N2; i++)
                 faddin (DF, N2, C22 + i*ldc, 1, C12 + i, ldc);
 
@@ -711,8 +711,8 @@ namespace FFLAS {
                 // U5 = U2 + P4^T  in C22 (only the lower triang part)
             DFElt U5Min, U5Max;
             if (Protected::NeedPreAddReduction (U5Min, U5Max, U2Min, U2Max, H4.Outmin, H4.Outmax, WH)){
-                freduce(F,N2,N2,C22,ldc);
-                freduce(F,N2,N2,C12,ldc);
+                freduce(F,uplo,N2,C22,ldc);
+                freduce(F,uplo,N2,C12,ldc);
             }
             faddin (DF, uplo, N2, C12, ldc, C22, ldc);
             freduce(F,N2,N2,C22,ldc);
@@ -743,8 +743,8 @@ namespace FFLAS {
                 // U3 = P1 + P2 in C11
             DFElt U3Min, U3Max;
             if (Protected::NeedPreAddReduction (U3Min, U3Max, H1.Outmin, H1.Outmax, H2.Outmin, H2.Outmax, WH)){
-                freduce(F,N2,N2,C11,ldc);
-                freduce(F,N2,N2,T,ldt);
+                freduce(F,uplo,N2,C11,ldc);
+                freduce(F,uplo,N2,T,ldt);
             }
             faddin (DF, uplo, N2, T, ldt, C11, ldc);
 

--- a/fflas-ffpack/fflas/fflas_level2.inl
+++ b/fflas-ffpack/fflas/fflas_level2.inl
@@ -177,6 +177,12 @@ namespace FFLAS {
     freduce (const Field& F, const size_t m , const size_t n,
              typename Field::Element_ptr A, const size_t lda);
 
+        //! freduce for square symmetric matrices
+    template<class Field>
+    void
+    freduce (const Field& F,  const FFLAS_UPLO uplo, const size_t N,
+             typename Field::Element_ptr A, const size_t lda);
+
     /** freduce
      * \f$A \gets  B mod F\f$.
      * @param F field


### PR DESCRIPTION
Contrarily to the symmetric variant of `faddin`, the symmetric variant of `freduce` accepts (some) rectangular matrices.
This PR makes the situation uniform: only square matrices (one dimension as parameter) in input.
As a side effect, the symmetric `ScalAndReduce` is also made to work only on square matrices.
In addition, this PR, changes many calls to `freduce` in `fsyrk_strassen` to calls to the symmetric variant (hence saving quite some ops).