### PR TITLE
Simd: add unpacklohi and pack methods [deleted, error with branch]

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -163,6 +163,29 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_pd(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    }
+
     /*
      * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,
      * and store the results in dst.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -172,6 +172,33 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_ps(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, b0, a1, b1 ]
+     *         r2 = [ a2, b2, a3, b3 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, a2, b0, b2 ]
+     *         r2 = [ a1, a3, b1, b3 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        __m128d t1 = _mm_castps_pd (_mm_permute_ps (a, 0xd8));
+        __m128d t2 = _mm_castps_pd (_mm_permute_ps (b, 0xd8));
+        r1 = _mm_castpd_ps (_mm_unpacklo_pd (t1, t2));
+        r2 = _mm_castpd_ps (_mm_unpackhi_pd (t1, t2));
+    }
+
     /*
      * Blend packed single-precision (32-bit) floating-point elements from a and b using control mask s,
      * and store the results in dst.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -529,17 +529,17 @@ template <> struct Simd128_impl<true, true, false, 2> : public Simd128_impl<true
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm_cmpgt_epi16(a, b);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm_cmplt_epi16(a, b);
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -211,6 +211,35 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi16(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: r1 = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         r2 = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: r1 = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         r2 = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2, idx;
+        /* 0x =  base_16 */
+        idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
+        t1 = _mm_shuffle_epi8 (a, idx);
+        t2 = _mm_shuffle_epi8 (b, idx);
+        r1 = _mm_unpacklo_epi64 (t1, t2);
+        r2 = _mm_unpackhi_epi64 (t1, t2);
+    }
+
     /*
      * Blend packed 16-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   :	[a0, ..., a7] int16_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -208,6 +208,34 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi32(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, b0, a1, b1 ]
+     *         r2 = [ a2, b2, a3, b3 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, a2, b0, b2 ]
+     *         r2 = [ a1, a3, b1, b3 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2;
+        /* 0xd8 = 3120 base_4 */
+        t1 = _mm_shuffle_epi32 (a, 0xd8);
+        t2 = _mm_shuffle_epi32 (b, 0xd8);
+        r1 = _mm_unpacklo_epi64 (t1, t2);
+        r2 = _mm_unpackhi_epi64 (t1, t2);
+    }
+
     /*
      * Blend packed 32-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   : [a0, a1, a2, a3] int32_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -562,17 +562,17 @@ template <> struct Simd128_impl<true, true, false, 4> : public Simd128_impl<true
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm_cmpgt_epi32(a, b);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm_cmplt_epi32(a, b);
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -223,6 +223,29 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi64(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    }
+
     /*
      * Blend packed 64-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   : [a0, a1] int64_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -573,10 +573,10 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
 #ifdef __FFLASFFPACK_HAVE_SSE4_2_INSTRUCTIONS
         vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-        return _mm_cmpgt_epi64(b, a);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
+        return _mm_cmpgt_epi64 (a, b);
 #else
         //#pragma warning "The simd greater function is emulated, it may impact the performances."
         Converter ca, cb;
@@ -589,10 +589,10 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
 #ifdef __FFLASFFPACK_HAVE_SSE4_2_INSTRUCTIONS
         vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-        return _mm_cmpgt_epi64(a, b);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
+        return _mm_cmpgt_epi64 (b, a);
 #else
         //#pragma warning "The simd greater function is emulated, it may impact the performances."
         Converter ca, cb;

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -652,17 +652,17 @@ template <> struct Simd256_impl<true, true, false, 2> : public Simd256_impl<true
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm256_cmpgt_epi16(a, b);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm256_cmpgt_epi16(b, a);
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -267,22 +267,43 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
 
     }
 
-    /*
-     * Unpack and interleave 16-bit integers from the low then high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a15] int16_t
-     [b0, ..., b15] int16_t
-     * Return :	[a0, b0, ..., a7, b7] int16_t
-     *			[a8, b8, ..., a15, b15] int16_t
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: r1 = [ a0, b0, a1, b1, ..., a6, b7, a7, b7 ]
+     *         r2 = [ a8, b8, a9, b9, ..., a14, b14, a15, b15 ]
      */
-    static INLINE void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
-        // using Simd256_64 = Simd256<uint64_t>;
-        // vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-        // vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
-        vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
-        s1 = unpacklo_twice(a1, b1);
-        s2 = unpackhi_twice(a1, b1);
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2;
+        /* 0xd8 = 3120 base_4 */
+        t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        r1 = _mm256_unpacklo_epi16 (t1, t2);
+        r2 = _mm256_unpackhi_epi16 (t1, t2);
+    }
 
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: r1 = [ a0, a2, ..., a12, a14, b0, b2, ..., b12, b14 ]
+     *         r2 = [ a1, a3, ..., a13, a15, b1, b3, ..., b13, b15 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2, s;
+        int16_t shuffle_idx[16] = { 0x0100, 0x0504, 0x0908, 0x0d0c,
+                                     0x0302, 0x0706, 0x0b0a, 0x0f0e,
+                                     0x0100, 0x0504, 0x0908, 0x0d0c,
+                                     0x0302, 0x0706, 0x0b0a, 0x0f0e };
+        s = loadu (shuffle_idx);
+        r1 = _mm256_shuffle_epi8 (a, s);
+        r2 = _mm256_shuffle_epi8 (b, s);
+        t1 = _mm256_unpacklo_epi64 (r1, r2);
+        t2 = _mm256_unpackhi_epi64 (r1, r2);
+        /* 0xd8 = 3120 base_4 */
+        r1 = _mm256_permute4x64_epi64 (t1, 0xd8);
+        r2 = _mm256_permute4x64_epi64 (t2, 0xd8);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -658,17 +658,17 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm256_cmpgt_epi32(a, b);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
         vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
         return _mm256_cmpgt_epi32(b, a);
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -618,18 +618,18 @@ template <> struct Simd256_impl<true, true, false, 8> : public Simd256_impl<true
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
         vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-        return _mm256_cmpgt_epi64(b,a);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
+        return _mm256_cmpgt_epi64(a, b);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
         vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-        return _mm256_cmpgt_epi64(a, b);
+        x = set1(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1));
+        a = vxor(x, a);
+        b = vxor(x, b);
+        return _mm256_cmpgt_epi64(b, a);
     }
 
     static INLINE CONST vect_t greater_eq(const vect_t a, const vect_t b) { return vor(greater(a, b), eq(a, b)); }

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -649,19 +649,13 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
     static INLINE CONST vect_t sra(const vect_t a) { return _mm256_srli_epi32(a, s); }
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
-        vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
-        return _mm256_cmpgt_epi32(a, b);
+        __m512i c = _mm512_set1_epi32(0xFFFFFFFF);
+        return _mm512_maskz_expand_epi32(_mm512_cmpgt_epu32_mask(a, b), c);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
-        vect_t x;
-        x = set1((static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(a,x);
-        b = sub(b,x);
-        return _mm256_cmpgt_epi32(b, a);
+        __m512i c = _mm512_set1_epi32(0xFFFFFFFF);
+        return _mm512_maskz_expand_epi32(_mm512_cmplt_epu32_mask(a, b), c);
     }
 
     static INLINE CONST vect_t greater_eq(const vect_t a, const vect_t b) { return vor(greater(a, b), eq(a, b)); }

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -669,27 +669,13 @@ template <> struct Simd512_impl<true, true, false, 8> : public Simd512_impl<true
     static INLINE CONST vect_t sra(const vect_t a) { return _mm512_srli_epi64(a, s); }
 
     static INLINE CONST vect_t greater(vect_t a, vect_t b) {
-        vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-
-        int64_t i = 0xFFFFFFFFFFFFFFFF;
-        __m512i c = _mm512_set1_epi64(i);
-        __m512i d = _mm512_maskz_expand_epi64(_mm512_cmpgt_epi64_mask(b, a), c);
-        return d;
+        __m512i c = _mm512_set1_epi64(0xFFFFFFFFFFFFFFFFLL);
+        return _mm512_maskz_expand_epi64(_mm512_cmpgt_epu64_mask(a, b), c);
     }
 
     static INLINE CONST vect_t lesser(vect_t a, vect_t b) {
-        vect_t x;
-        x = set1(-(static_cast<scalar_t>(1) << (sizeof(scalar_t) * 8 - 1)));
-        a = sub(x, a);
-        b = sub(x, b);
-
-        int64_t i = 0xFFFFFFFFFFFFFFFF;
-        __m512i c = _mm512_set1_epi64(i);
-        __m512i d = _mm512_maskz_expand_epi64(_mm512_cmpgt_epi64_mask(a, b), c);
-        return d;
+        __m512i c = _mm512_set1_epi64(0xFFFFFFFFFFFFFFFFLL);
+        return _mm512_maskz_expand_epi64(_mm512_cmplt_epu64_mask(a, b), c);
     }
 
     static INLINE CONST vect_t greater_eq(const vect_t a, const vect_t b) { return vor(greater(a, b), eq(a, b)); }

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -460,6 +460,91 @@ struct ScalFunctions<Element,
 };
 
 /******************************************************************************/
+/* Tests that does not fit in the generic framework of test_op ****************/
+/******************************************************************************/
+template <class Simd, class Scal>
+bool
+do_test_greater_with_zero ()
+{
+    using Element = typename Simd::scalar_t;
+    using SimdVect = typename Simd::vect_t;
+    constexpr size_t SimdVectSize = Simd::vect_size;
+
+    vector<Element> v(SimdVectSize), out_scal(SimdVectSize),
+                                     out_simd(SimdVectSize);
+    generate_random_vector (v);
+
+    /* compute with scalar function */
+    for(size_t i = 0 ; i < SimdVectSize ; i++)
+        out_scal[i] = Scal::greater (0, v[i]);
+
+    /* compute with SIMD function */
+    SimdVect r = Simd::greater (Simd::set1 (0), Simd::loadu (v.data()));
+    Simd::storeu (out_simd.data(), r);
+
+    /* comparison */
+    auto eq = check_eq<Element>;
+    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
+
+    /* print result line */
+    cout << Simd::type_string() << "<" << TypeName<Element>()
+         << "> test greater_with_zero"
+         << " " << string (39 - strlen(TypeName<Element>()), '.')
+         << " " << (res ? "success" : "failure") << endl;
+
+    /* in case of error, print all input and output values */
+    if(!res) {
+        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
+        cout << "v: " << v << endl;
+        cout << "out_scal: " << out_scal << endl;
+        cout << "out_simd: " << out_simd << endl;
+        cout << string (80, '-') << endl;
+    }
+    return res;
+}
+
+template <class Simd, class Scal>
+bool
+do_test_lesser_with_zero ()
+{
+    using Element = typename Simd::scalar_t;
+    using SimdVect = typename Simd::vect_t;
+    constexpr size_t SimdVectSize = Simd::vect_size;
+
+    vector<Element> v(SimdVectSize), out_scal(SimdVectSize),
+                                     out_simd(SimdVectSize);
+    generate_random_vector (v);
+
+    /* compute with scalar function */
+    for(size_t i = 0 ; i < SimdVectSize ; i++)
+        out_scal[i] = Scal::lesser (0, v[i]);
+
+    /* compute with SIMD function */
+    SimdVect r = Simd::lesser (Simd::set1 (0), Simd::loadu (v.data()));
+    Simd::storeu (out_simd.data(), r);
+
+    /* comparison */
+    auto eq = check_eq<Element>;
+    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
+
+    /* print result line */
+    cout << Simd::type_string() << "<" << TypeName<Element>()
+         << "> test lesser_with_zero"
+         << " " << string (40 - strlen(TypeName<Element>()), '.')
+         << " " << (res ? "success" : "failure") << endl;
+
+    /* in case of error, print all input and output values */
+    if(!res) {
+        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
+        cout << "v: " << v << endl;
+        cout << "out_scal: " << out_scal << endl;
+        cout << "out_simd: " << out_simd << endl;
+        cout << string (80, '-') << endl;
+    }
+    return res;
+}
+
+/******************************************************************************/
 /* Test one SIMD implem *******************************************************/
 /******************************************************************************/
 
@@ -495,8 +580,10 @@ test_impl () {
     TEST_ONE_OP (fnmadd);
     TEST_ONE_OP (fnmaddin);
     TEST_ONE_OP (lesser);
+    btest &= do_test_lesser_with_zero<simd, Scal> ();
     TEST_ONE_OP (lesser_eq);
     TEST_ONE_OP (greater);
+    btest &= do_test_greater_with_zero<simd, Scal> ();
     TEST_ONE_OP (greater_eq);
     TEST_ONE_OP (eq);
 
@@ -537,8 +624,10 @@ test_impl () {
     TEST_ONE_OP (fnmaddx);
     TEST_ONE_OP (fnmaddxin);
     TEST_ONE_OP (lesser);
+    btest &= do_test_lesser_with_zero<simd, Scal> ();
     TEST_ONE_OP (lesser_eq);
     TEST_ONE_OP (greater);
+    btest &= do_test_greater_with_zero<simd, Scal> ();
     TEST_ONE_OP (greater_eq);
     TEST_ONE_OP (eq);
     TEST_ONE_OP (template sra<3>);


### PR DESCRIPTION
This PR proposes to add two new method to the Simd structs: unpacklohi and pack. These two methods are currently implemented in `linbox/algorithms/polynomial-matrix/fft-simd.h` in LinBox. The input and output of theses two methods are:

```
unpacklohi:
      Input (with n = Simd::vect_size):
             a = [ a0, a1, ..., an-1 ]
             b = [ b0, b1, ..., bn-1 ]
      Ouput (with l = n/2 = Simd::vect_size/2):
            r1 = [ a0, b0, a1, b1, ..., al-1, bl-1 ]
            r2 = [ al, bl, al+1, bl+1, ..., an-1, bn-1 ]
```

```
pack:
     Input (with n = Simd::vect_size):
            a = [ a0, a1, ..., an-1 ]
            b = [ b0, b1, ..., bn-1 ]
     Ouput (with l = n/2 = Simd::vect_size/2):
            r1 = [ a0, a2, ..., an-2, b0, b2, ..., bn-2 ]
            r2 = [ a1, a3, ..., an-1, b1, b3, ..., bn-1 ]
```


Note that:
- the semantic of unpacklohi is different from the semantic of unpacklo and unpackhi from the intrinsics but follows the semantic of unpacklo and unpackhi in the simd structs of fflas (when these methods exist).
- unpacklohi and pack are not implement for Simd512 as I have no way of testing this case




When this PR is accepted, I will remove similar code from `linbox/algorithms/polynomial-matrix/fft-simd.h` in LinBox and update the rest of the fft code accordingly.
