### PR TITLE
Add more precise type_string to SIMD structs

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128.inl
@@ -28,23 +28,12 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_INL
 
-struct Simd128fp_base {
-
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd128"; }
-
-
-};
-
 struct Simd128i_base {
 
     /*
      * alias to 128 bit simd register
      */
     using vect_t = __m128i;
-
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd128"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -28,6 +28,7 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_double_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_double_INL
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -35,7 +36,7 @@
 /*
  * Simd128 specialized for double
  */
-template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
+template <> struct Simd128_impl<true, false, true, 8> {
 #if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
 
     /*
@@ -52,6 +53,14 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 2;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -28,6 +28,7 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd128_float_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd128_float_INL
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -35,7 +36,7 @@
 /*
  * Simd128 specialized for float
  */
-template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
+template <> struct Simd128_impl<true, false, true, 4> {
 #if defined(__FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS)
 
     /*
@@ -52,6 +53,14 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 4;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -33,6 +33,7 @@
 #error "You need SSE instructions to perform 128 bits operations on int16"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -56,6 +57,14 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 8;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -434,6 +443,14 @@ template <> struct Simd128_impl<true, true, false, 2> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint16_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -37,6 +37,7 @@
 #include "fflas-ffpack/fflas/fflas_simd/simd128_int64.inl"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -60,6 +61,14 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 4;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -468,6 +477,14 @@ template <> struct Simd128_impl<true, true, false, 4> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -34,6 +34,7 @@
 #error "You need SSE instructions to perform 128 bits operations on int64"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -57,6 +58,14 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 2;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -480,6 +489,14 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -31,9 +31,6 @@
 struct Simd256fp_base {
 #if defined(__FFLASFFPACK_HAVE_AVX_INSTRUCTIONS)
 
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd256"; }
-
     /*
      * Shuffle 128-bits selected by imm8 from a and b, and store the results in dst.
      * Args   :	[a0, a1]
@@ -77,9 +74,6 @@ struct Simd256i_base {
      * alias to 256 bit simd register
      */
     using vect_t = __m256i;
-
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd256"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -32,6 +32,7 @@
 #error "You need AVX instructions to perform 256bits operations on double"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -54,6 +55,14 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
      *	number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 4;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *	alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -28,6 +28,7 @@
 #ifndef __FFLASFFPACK_fflas_ffpack_utils_simd256_float_INL
 #define __FFLASFFPACK_fflas_ffpack_utils_simd256_float_INL
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -51,6 +52,14 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
      *	number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 8;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *	alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -33,6 +33,7 @@
 #error "You need AVX2 instructions to perform 256bits operations on int16_t"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -66,6 +67,14 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 16;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -546,6 +555,14 @@ template <> struct Simd256_impl<true, true, false, 2> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint16_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -37,6 +37,7 @@
 #include "fflas-ffpack/fflas/fflas_simd/simd256_int64.inl"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -70,6 +71,14 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 8;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -558,6 +567,14 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -34,6 +34,7 @@
 #error "You need AVX2 instructions to perform 256bits operations on int64_t"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -67,6 +68,14 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 4;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -519,6 +528,14 @@ template <> struct Simd256_impl<true, true, false, 8> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd512.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512.inl
@@ -28,23 +28,12 @@
 #ifndef __FFLASFFPACK_simd512_INL
 #define __FFLASFFPACK_simd512_INL
 
-struct Simd512fp_base {
-
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd512"; }
-
-
-};
-
 struct Simd512i_base {
 
     /*
      * alias to 512 bit simd register
      */
     using vect_t = __m512i;
-
-    /* Name of the Simd struct */
-    static inline const std::string type_string () { return "Simd512"; }
 
     /*
      *  Return vector of type vect_t with all elements set to zero

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -31,6 +31,7 @@
 #error "You need AVX512 instructions to perform 512bits operations on double"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -38,7 +39,7 @@
 /*
  * Simd512 specialized for double
  */
-template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
+template <> struct Simd512_impl<true, false, true, 8> {
     /*
      * alias to 512 bit simd register
      */
@@ -53,6 +54,14 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      *	number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 8;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *	alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -27,6 +27,7 @@
 #ifndef __FFLASFFPACK_simd512_float_INL
 #define __FFLASFFPACK_simd512_float_INL
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -34,7 +35,7 @@
 /*
  * Simd512 specialized for float
  */
-template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
+template <> struct Simd512_impl<true, false, true, 4> {
 #if defined(__FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS)
     /*
      * alias to 512 bit simd register
@@ -50,6 +51,14 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      *	number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 16;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *	alignement required by scalar_t pointer to be loaded in a vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -33,6 +33,7 @@
 
 #include "fflas-ffpack/fflas/fflas_simd/simd512_int64.inl"
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -66,6 +67,14 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd512i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 16;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -550,6 +559,14 @@ template <> struct Simd256_impl<true, true, false, 4> : public Simd256_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint32_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -32,6 +32,7 @@
 #error "You need AVX512 instructions to perform 512bits operations on int64_t"
 #endif
 
+#include "givaro/givtypestring.h"
 #include "fflas-ffpack/utils/align-allocator.h"
 #include <vector>
 #include <type_traits>
@@ -65,6 +66,14 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
      *  number of scalar_t in a simd register
      */
     static const constexpr size_t vect_size = 8;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     /*
      *  alignement required by scalar_t pointer to be loaded in a vect_t
@@ -563,6 +572,14 @@ template <> struct Simd512_impl<true, true, false, 8> : public Simd512_impl<true
      * define the scalar type corresponding to the specialization
      */
     using scalar_t = uint64_t;
+
+    /*
+     *  string describing the Simd struct
+     */
+    static const std::string type_string () {
+        return "Simd" + std::to_string(8*vect_size*sizeof(scalar_t)) + "<"
+                      + Givaro::TypeString<scalar_t>::get() + ">";
+    }
 
     using aligned_allocator = AlignedAllocator<scalar_t, Alignment(alignment)>;
     using aligned_vector = std::vector<scalar_t, aligned_allocator>;

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -181,8 +181,8 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
 
     /* print result line */
-    cout << Simd::type_string() << "<" << TypeName<Element>() << ">::" << fname
-         << " " << string (60 - fname.size() - strlen(TypeName<Element>()), '.')
+    cout << Simd::type_string() << "::" << fname << " "
+         << string (69 - fname.size() - Simd::type_string().size(), '.')
          << " " << (res ? "success" : "failure") << endl;
 
     /* in case of error, print all input and output values */


### PR DESCRIPTION
This PR adds more precise static method type_string to all SIMD structs. For example, instead of returning "Simd256", it will now returns "Simd256<uint32_t>".

This PR should be merged, once PR linbox-team/givaro#162 from givaro is accepted, as it uses a new file from linbox-team/givaro#162. 