### PR TITLE
Simd: add unpacklohi and pack methods

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -148,42 +148,99 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
 #endif
 
     /*
-     * Unpack and interleave double-precision (64-bit) floating-point elements from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1] double
-     [b0, b1] double
-     * Return : [a0, b0] double
-     */
-    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) { return _mm_unpacklo_pd(a, b); }
-
-    /*
-     * Unpack and interleave double-precision (64-bit) floating-point elements from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1] double
-     [b0, b1] double
-     * Return : [a1, b1] double
-     */
-    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_pd(a, b); }
-
-    /* unpacklohi:
-     * Args: a = [ a0, a1  ]
-     *       b = [ b0, b1  ]
-     * Return: r1 = [ a0, b0 ]
-     *         r2 = [ a1, b1 ]
-     */
-    static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        r1 = unpacklo (a, b);
-        r2 = unpackhi (a, b);
-    }
-
-    /* pack:
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the low half of a and b.
      * Args: a = [ a0, a1 ]
      *       b = [ b0, b1 ]
-     * Return: r1 = [ a0, b0 ]
-     *         r2 = [ a1, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpacklo_pd(a, b);
+    }
+
+    /*
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the high half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpackhi_pd(a, b);
+    }
+
+    /*
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the low half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        return unpacklo_intrinsic(a, b);
+    }
+
+    /*
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the high half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        return unpackhi_intrinsic(a, b);
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: lo = [ a0, b0 ]
+     *         hi = [ a1, b1 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        lo = unpacklo (a, b);
+        hi = unpackhi (a, b);
+    }
+
+    /*
+     * Pack double-precision (64-bit) floating-point elements from the even
+     * positions of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        return unpacklo (a, b); /* same as unpacklo for vect_size = 2 */
+    }
+
+    /*
+     * Pack double-precision (64-bit) floating-point elements from the odd
+     * positions of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        return unpackhi (a, b); /* same as unpackhi for vect_size = 2 */
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: even = [ a0, b0 ]
+     *         odd  = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        even = pack_even (a, b);
+        odd = pack_odd (a, b);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -163,6 +163,29 @@ template <> struct Simd128_impl<true, false, true, 8> : public Simd128fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_pd(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    }
+
     /*
      * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,
      * and store the results in dst.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -157,46 +157,108 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
 #endif
 
     /*
-     * Unpack and interleave single-precision (32-bit) floating-point elements from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] float
-     [b0, b1, b2, b3] float
-     * Return : [a0, b0, a1, b1] float
-     */
-    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) { return _mm_unpacklo_ps(a, b); }
-
-    /*
-     * Unpack and interleave single-precision (32-bit) floating-point elements from the high half a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] float
-     [b0, b1, b2, b3] float
-     * Return : [a2, b2, a3, b3] float
-     */
-    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_ps(a, b); }
-
-    /* unpacklohi:
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the low half of a and b.
      * Args: a = [ a0, a1, a2, a3 ]
      *       b = [ b0, b1, b2, b3 ]
-     * Return: r1 = [ a0, b0, a1, b1 ]
-     *         r2 = [ a2, b2, a3, b3 ]
+     * Return:   [ a0, b0, a1, b1 ]
      */
-    static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        r1 = unpacklo (a, b);
-        r2 = unpackhi (a, b);
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpacklo_ps(a, b);
     }
 
-    /* pack:
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the high half of a and b.
      * Args: a = [ a0, a1, a2, a3 ]
      *       b = [ b0, b1, b2, b3 ]
-     * Return: r1 = [ a0, a2, b0, b2 ]
-     *         r2 = [ a1, a3, b1, b3 ]
+     * Return:   [ a2, b2, a3, b3 ]
+     */
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpackhi_ps(a, b);
+    }
+
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a0, b0, a1, b1 ]
+     */
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        return unpacklo_intrinsic(a, b);
+    }
+
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a2, b2, a3, b3 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        return unpackhi_intrinsic(a, b);
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: lo = [ a0, b0, a1, b1 ]
+     *         hi = [ a2, b2, a3, b3 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        lo = unpacklo (a, b);
+        hi = unpackhi (a, b);
+    }
+
+    /*
+     * Pack single-precision (32-bit) floating-point elements from the even
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a0, a2, b0, b2 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
         /* 0xd8 = 3120 base_4 */
         __m128d t1 = _mm_castps_pd (_mm_permute_ps (a, 0xd8));
         __m128d t2 = _mm_castps_pd (_mm_permute_ps (b, 0xd8));
-        r1 = _mm_castpd_ps (_mm_unpacklo_pd (t1, t2));
-        r2 = _mm_castpd_ps (_mm_unpackhi_pd (t1, t2));
+        return _mm_castpd_ps (_mm_unpacklo_pd (t1, t2));
+    }
+
+    /*
+     * Pack single-precision (32-bit) floating-point elements from the odd
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a1, a3, b1, b3 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        __m128d t1 = _mm_castps_pd (_mm_permute_ps (a, 0xd8));
+        __m128d t2 = _mm_castps_pd (_mm_permute_ps (b, 0xd8));
+        return _mm_castpd_ps (_mm_unpackhi_pd (t1, t2));
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: even = [ a0, a2, b0, b2 ]
+     *         odd  = [ a1, a3, b1, b3 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        __m128d t1 = _mm_castps_pd (_mm_permute_ps (a, 0xd8));
+        __m128d t2 = _mm_castps_pd (_mm_permute_ps (b, 0xd8));
+        even = _mm_castpd_ps (_mm_unpacklo_pd (t1, t2));
+        odd = _mm_castpd_ps (_mm_unpackhi_pd (t1, t2));
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -172,6 +172,33 @@ template <> struct Simd128_impl<true, false, true, 4> : public Simd128fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_ps(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, b0, a1, b1 ]
+     *         r2 = [ a2, b2, a3, b3 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, a2, b0, b2 ]
+     *         r2 = [ a1, a3, b1, b3 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        __m128d t1 = _mm_castps_pd (_mm_permute_ps (a, 0xd8));
+        __m128d t2 = _mm_castps_pd (_mm_permute_ps (b, 0xd8));
+        r1 = _mm_castpd_ps (_mm_unpacklo_pd (t1, t2));
+        r2 = _mm_castpd_ps (_mm_unpackhi_pd (t1, t2));
+    }
+
     /*
      * Blend packed single-precision (32-bit) floating-point elements from a and b using control mask s,
      * and store the results in dst.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -211,6 +211,35 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi16(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: r1 = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         r2 = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: r1 = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         r2 = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2, idx;
+        /* 0x =  base_16 */
+        idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
+        t1 = _mm_shuffle_epi8 (a, idx);
+        t2 = _mm_shuffle_epi8 (b, idx);
+        r1 = _mm_unpacklo_epi64 (t1, t2);
+        r2 = _mm_unpackhi_epi64 (t1, t2);
+    }
+
     /*
      * Blend packed 16-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   :	[a0, ..., a7] int16_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -196,48 +196,101 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
     }
 
     /*
-     * Unpack and interleave 16-bit integers from the low half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int16_t
-     [b0, ..., b7] int16_t
-     * Return :	[a0, b0, ..., a3, b3] int16_t
-     */
-    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) { return _mm_unpacklo_epi16(a, b); }
-
-    /*
-     * Unpack and interleave 16-bit integers from the high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int16_t
-     [b0, ..., b7] int16_t
-     * Return :	[a4, b4, ..., a7, b7] int16_t
-     */
-    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi16(a, b); }
-
-    /* unpacklohi:
+     * Unpack and interleave 16-bit integers from the low half of a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
-     *         r2 = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
      */
-    static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        r1 = unpacklo (a, b);
-        r2 = unpackhi (a, b);
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpacklo_epi16(a, b);
     }
 
-    /* pack:
+    /*
+     * Unpack and interleave 16-bit integers from the high half of a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
-     *         r2 = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpackhi_epi16(a, b);
+    }
+
+    /*
+     * Unpack and interleave 16-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     */
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        return unpacklo_intrinsic(a, b);
+    }
+
+    /*
+     * Unpack and interleave 16-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        return unpackhi_intrinsic(a, b);
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: lo = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         hi = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        vect_t t1, t2, idx;
-        /* 0x =  base_16 */
-        idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
-        t1 = _mm_shuffle_epi8 (a, idx);
-        t2 = _mm_shuffle_epi8 (b, idx);
-        r1 = _mm_unpacklo_epi64 (t1, t2);
-        r2 = _mm_unpackhi_epi64 (t1, t2);
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        lo = unpacklo (a, b);
+        hi = unpackhi (a, b);
+    }
+    /*
+     * Pack 16-bit integers from the even positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        vect_t idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
+        vect_t t1 = _mm_shuffle_epi8 (a, idx);
+        vect_t t2 = _mm_shuffle_epi8 (b, idx);
+        return _mm_unpacklo_epi64 (t1, t2);
+    }
+
+    /*
+     * Pack 16-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        vect_t idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
+        vect_t t1 = _mm_shuffle_epi8 (a, idx);
+        vect_t t2 = _mm_shuffle_epi8 (b, idx);
+        return _mm_unpackhi_epi64 (t1, t2);
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: even = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         odd = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        vect_t idx = _mm_set_epi8 (15,14,11,10,7,6,3,2,13,12,9,8,5,4,1,0);
+        vect_t t1 = _mm_shuffle_epi8 (a, idx);
+        vect_t t2 = _mm_shuffle_epi8 (b, idx);
+        even = _mm_unpacklo_epi64 (t1, t2);
+        odd = _mm_unpackhi_epi64 (t1, t2);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int32.inl
@@ -208,6 +208,34 @@ template <> struct Simd128_impl<true, true, true, 4> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi32(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, b0, a1, b1 ]
+     *         r2 = [ a2, b2, a3, b3 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: r1 = [ a0, a2, b0, b2 ]
+     *         r2 = [ a1, a3, b1, b3 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2;
+        /* 0xd8 = 3120 base_4 */
+        t1 = _mm_shuffle_epi32 (a, 0xd8);
+        t2 = _mm_shuffle_epi32 (b, 0xd8);
+        r1 = _mm_unpacklo_epi64 (t1, t2);
+        r2 = _mm_unpackhi_epi64 (t1, t2);
+    }
+
     /*
      * Blend packed 32-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   : [a0, a1, a2, a3] int32_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -223,6 +223,29 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi64(a, b); }
 
+    /* unpacklohi:
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        r1 = unpacklo (a, b);
+        r2 = unpackhi (a, b);
+    }
+
+    /* pack:
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: r1 = [ a0, b0 ]
+     *         r2 = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    }
+
     /*
      * Blend packed 64-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   : [a0, a1] int64_t

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -208,42 +208,93 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int64_t
-     [b0, b1] int64_t
-     * Return : [a0, b0] int64_t
-     */
-    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) { return _mm_unpacklo_epi64(a, b); }
-
-    /*
-     * Unpack and interleave 64-bit integers from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int64_t
-     [b0, b1] int64_t
-     * Return : [a1, b1] int64_t
-     */
-    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) { return _mm_unpackhi_epi64(a, b); }
-
-    /* unpacklohi:
-     * Args: a = [ a0, a1  ]
-     *       b = [ b0, b1  ]
-     * Return: r1 = [ a0, b0 ]
-     *         r2 = [ a1, b1 ]
-     */
-    static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        r1 = unpacklo (a, b);
-        r2 = unpackhi (a, b);
-    }
-
-    /* pack:
+     * Unpack and interleave 64-bit integers from the low half of a and b.
      * Args: a = [ a0, a1 ]
      *       b = [ b0, b1 ]
-     * Return: r1 = [ a0, b0 ]
-     *         r2 = [ a1, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpacklo_epi64(a, b);
+    }
+
+    /*
+     * Unpack and interleave 64-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm_unpackhi_epi64(a, b);
+    }
+
+    /*
+     * Unpack and interleave 64-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        return unpacklo_intrinsic(a, b);
+    }
+
+    /*
+     * Unpack and interleave 64-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        return unpackhi_intrinsic(a, b);
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1  ]
+     *       b = [ b0, b1  ]
+     * Return: lo = [ a0, b0 ]
+     *         hi = [ a1, b1 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        unpacklohi (r1, r2, a, b); /* same as unpacklohi for vect_size = 2 */
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        lo = unpacklo (a, b);
+        hi = unpackhi (a, b);
+    }
+
+    /*
+     * Pack 64-bit integers from the even positions of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a0, b0 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        return unpacklo (a, b); /* same as unpacklo for vect_size = 2 */
+    }
+
+    /*
+     * Pack 64-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return:   [ a1, b1 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        return unpackhi (a, b); /* same as unpackhi for vect_size = 2 */
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     * Return: even = [ a0, b0 ]
+     *         odd  = [ a1, b1 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        even = pack_even (a, b);
+        odd = pack_odd (a, b);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256.inl
@@ -49,25 +49,6 @@ struct Simd256fp_base {
     static INLINE CONST __m256 permute128(const __m256 a, const __m256 b) {
         return _mm256_permute2f128_ps(a, b, s);
     }
-
-    /*
-     * Unpack and interleave 128-bit integers from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int128_t
-     [b0, b1] int128_t
-     * Return : [a0, b0] int128_t
-     */
-    static INLINE CONST __m256d unpacklo128(const __m256d a, const __m256d b) { return permute128<0x20>(a, b); }
-    static INLINE CONST __m256 unpacklo128(const __m256 a, const __m256 b) { return permute128<0x20>(a, b); }
-
-    /*
-     * Unpack and interleave 128-bit integers from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int128_t
-     [b0, b1] int128_t
-     * Return : [a1, b1] int128_t
-     */
-    static INLINE CONST __m256d unpackhi128(const __m256d a, const __m256d b) { return permute128<0x31>(a, b); }
-    static INLINE CONST __m256 unpackhi128(const __m256 a, const __m256 b) { return permute128<0x31>(a, b); }
-
 #endif
 };
 
@@ -155,22 +136,6 @@ struct Simd256i_base {
     static INLINE CONST vect_t permute128(const vect_t a, const vect_t b) {
         return _mm256_permute2x128_si256(a, b, s);
     }
-
-    /*
-     * Unpack and interleave 128-bit integers from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int128_t
-     [b0, b1] int128_t
-     * Return : [a0, b0] int128_t
-     */
-    static INLINE CONST vect_t unpacklo128(const vect_t a, const vect_t b) { return permute128<0x20>(a, b); }
-
-    /*
-     * Unpack and interleave 128-bit integers from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1] int128_t
-     [b0, b1] int128_t
-     * Return : [a1, b1] int128_t
-     */
-    static INLINE CONST vect_t unpackhi128(const vect_t a, const vect_t b) { return permute128<0x31>(a, b); }
 #endif
 };
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -149,58 +149,164 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
     }
 
     /*
-     * Unpack and interleave single-precision (32-bit) floating-point elements from the low half of each 128-bit lane in a and b,
-     * and store the results in dst.
-     * Args   :	[a0, ..., a7] float
-     [b0, ..., b7] float
-     * Return :	[a0, b0, a1, b1, a4, b4, a5, b5] float
-     */
-    static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) { return _mm256_unpacklo_ps(a, b); }
-
-    /*
-     * Unpack and interleave single-precision (32-bit) floating-point elements from the high half of each 128-bit lane in a and b,
-     * and store the results in dst.
-     * Args   :	[a0, ..., a7] float
-     [b0, ..., b7] float
-     * Return :	[a2, b2, a3, b3, a6, b6, a7, b7] float
-     */
-    static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) { return _mm256_unpackhi_ps(a, b); }
-
-    /* unpacklohi:
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the low half of each 128-bit lane in a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
-     *         r2 = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     * Return:   [ a0, b0, a1, b1, a4, b4, a5, b5 ]
      */
-    static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpacklo_ps(a, b);
+    }
+
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the high half of each 128-bit lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a2, b2, a3, b3, a6, b6, a7, b7 ]
+     */
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpackhi_ps(a, b);
+    }
+
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     */
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
 /* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
 #ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
-        vect_t t1, t2;
         /* 0xd8 = 3120 base_4 */
-        t1 = _mm256_castpd_ps (_mm256_permute4x64_pd
+        vect_t t1 = _mm256_castpd_ps (_mm256_permute4x64_pd
                                             (_mm256_castps_pd (a), 0xd8));
-        t2 = _mm256_castpd_ps (_mm256_permute4x64_pd
+        vect_t t2 = _mm256_castpd_ps (_mm256_permute4x64_pd
                                             (_mm256_castps_pd (b), 0xd8));
-        r1 = _mm256_unpacklo_ps (t1, t2);
-        r2 = _mm256_unpackhi_ps (t1, t2);
+        return _mm256_unpacklo_ps (t1, t2);
 #else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
-        vect_t t1, t2;
-        t1 = _mm256_unpacklo_ps (a, b);
-        t2 = _mm256_unpackhi_ps (a, b);
-        r1 = _mm256_permute2f128_ps (t1, t2, 0x20);
-        r2 = _mm256_permute2f128_ps (t1, t2, 0x31);
+        vect_t t1 = _mm256_unpacklo_ps (a, b);
+        vect_t t2 = _mm256_unpackhi_ps (a, b);
+        return _mm256_permute2f128_ps (t1, t2, 0x20);
 #endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
     }
 
-    /* pack:
+    /*
+     * Unpack and interleave single-precision (32-bit) floating-point elements
+     * from the high half of a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
-     *         r2 = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+/* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_castpd_ps (_mm256_permute4x64_pd
+                                            (_mm256_castps_pd (a), 0xd8));
+        vect_t t2 = _mm256_castpd_ps (_mm256_permute4x64_pd
+                                            (_mm256_castps_pd (b), 0xd8));
+        return _mm256_unpackhi_ps (t1, t2);
+#else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
+        vect_t t1 = _mm256_unpacklo_ps (a, b);
+        vect_t t2 = _mm256_unpackhi_ps (a, b);
+        return _mm256_permute2f128_ps (t1, t2, 0x31);
+#endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: lo = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         hi = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+/* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_castpd_ps (_mm256_permute4x64_pd
+                                            (_mm256_castps_pd (a), 0xd8));
+        vect_t t2 = _mm256_castpd_ps (_mm256_permute4x64_pd
+                                            (_mm256_castps_pd (b), 0xd8));
+        lo = _mm256_unpacklo_ps (t1, t2);
+        hi = _mm256_unpackhi_ps (t1, t2);
+#else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
+        vect_t t1 = _mm256_unpacklo_ps (a, b);
+        vect_t t2 = _mm256_unpackhi_ps (a, b);
+        lo = _mm256_permute2f128_ps (t1, t2, 0x20);
+        hi = _mm256_permute2f128_ps (t1, t2, 0x31);
+#endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
+    }
+
+    /*
+     * Pack single-precision (32-bit) floating-point elements from the even
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+/* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+        /* 0xd8 = 3120 base_4 */
+        __m256d t1 = _mm256_castps_pd (_mm256_permute_ps (a, 0xd8));
+        __m256d t2 = _mm256_castps_pd (_mm256_permute_ps (b, 0xd8));
+        __m256d p1 = _mm256_unpacklo_pd (t1, t2);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_castpd_ps (_mm256_permute4x64_pd (p1, 0xd8));
+#else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
+        /* 0xd8 = 3120 base_4 */
+        __m256d pa = _mm256_castps_pd (_mm256_permute_ps (a, 0xd8));
+        __m256d pb = _mm256_castps_pd (_mm256_permute_ps (b, 0xd8));
+        __m256d t1 = _mm256_permute2f128_pd (pa, pb, 0x20);
+        __m256d t2 = _mm256_permute2f128_pd (pa, pb, 0x31);
+        return _mm256_castpd_ps (_mm256_unpacklo_pd (t1, t2));
+#endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
+    }
+
+    /*
+     * Pack single-precision (32-bit) floating-point elements from the odd
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+/* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+        /* 0xd8 = 3120 base_4 */
+        __m256d t1 = _mm256_castps_pd (_mm256_permute_ps (a, 0xd8));
+        __m256d t2 = _mm256_castps_pd (_mm256_permute_ps (b, 0xd8));
+        __m256d p2 = _mm256_unpackhi_pd (t1, t2);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_castpd_ps (_mm256_permute4x64_pd (p2, 0xd8));
+#else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
+        /* 0xd8 = 3120 base_4 */
+        __m256d pa = _mm256_castps_pd (_mm256_permute_ps (a, 0xd8));
+        __m256d pb = _mm256_castps_pd (_mm256_permute_ps (b, 0xd8));
+        __m256d t1 = _mm256_permute2f128_pd (pa, pb, 0x20);
+        __m256d t2 = _mm256_permute2f128_pd (pa, pb, 0x31);
+        return _mm256_castpd_ps (_mm256_unpackhi_pd (t1, t2));
+#endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: even = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         odd = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
 /* _mm256_permute4x64_pd requires AVX2 but we only require AVX here */
 #ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
         /* 0xd8 = 3120 base_4 */
@@ -209,17 +315,16 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
         __m256d p1 = _mm256_unpacklo_pd (t1, t2);
         __m256d p2 = _mm256_unpackhi_pd (t1, t2);
         /* 0xd8 = 3120 base_4 */
-        r1 = _mm256_castpd_ps (_mm256_permute4x64_pd (p1, 0xd8));
-        r2 = _mm256_castpd_ps (_mm256_permute4x64_pd (p2, 0xd8));
+        even = _mm256_castpd_ps (_mm256_permute4x64_pd (p1, 0xd8));
+        odd = _mm256_castpd_ps (_mm256_permute4x64_pd (p2, 0xd8));
 #else /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS not defined */
         /* 0xd8 = 3120 base_4 */
         __m256d pa = _mm256_castps_pd (_mm256_permute_ps (a, 0xd8));
         __m256d pb = _mm256_castps_pd (_mm256_permute_ps (b, 0xd8));
         __m256d t1 = _mm256_permute2f128_pd (pa, pb, 0x20);
         __m256d t2 = _mm256_permute2f128_pd (pa, pb, 0x31);
-        r1 = _mm256_castpd_ps (_mm256_unpacklo_pd (t1, t2));
-        r2 = _mm256_castpd_ps (_mm256_unpackhi_pd (t1, t2));
-
+        even = _mm256_castpd_ps (_mm256_unpacklo_pd (t1, t2));
+        odd = _mm256_castpd_ps (_mm256_unpackhi_pd (t1, t2));
 #endif /* __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS */
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -267,22 +267,43 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
 
     }
 
-    /*
-     * Unpack and interleave 16-bit integers from the low then high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a15] int16_t
-     [b0, ..., b15] int16_t
-     * Return :	[a0, b0, ..., a7, b7] int16_t
-     *			[a8, b8, ..., a15, b15] int16_t
+    /* unpacklohi:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: r1 = [ a0, b0, a1, b1, ..., a6, b7, a7, b7 ]
+     *         r2 = [ a8, b8, a9, b9, ..., a14, b14, a15, b15 ]
      */
-    static INLINE void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
-        // using Simd256_64 = Simd256<uint64_t>;
-        // vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-        // vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
-        vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
-        s1 = unpacklo_twice(a1, b1);
-        s2 = unpackhi_twice(a1, b1);
+    static INLINE void
+    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2;
+        /* 0xd8 = 3120 base_4 */
+        t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        r1 = _mm256_unpacklo_epi16 (t1, t2);
+        r2 = _mm256_unpackhi_epi16 (t1, t2);
+    }
 
+    /* pack:
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: r1 = [ a0, a2, ..., a12, a14, b0, b2, ..., b12, b14 ]
+     *         r2 = [ a1, a3, ..., a13, a15, b1, b3, ..., b13, b15 ]
+     */
+    static INLINE void
+    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
+        vect_t t1, t2, s;
+        int16_t shuffle_idx[16] = { 0x0100, 0x0504, 0x0908, 0x0d0c,
+                                     0x0302, 0x0706, 0x0b0a, 0x0f0e,
+                                     0x0100, 0x0504, 0x0908, 0x0d0c,
+                                     0x0302, 0x0706, 0x0b0a, 0x0f0e };
+        s = loadu (shuffle_idx);
+        r1 = _mm256_shuffle_epi8 (a, s);
+        r2 = _mm256_shuffle_epi8 (b, s);
+        t1 = _mm256_unpacklo_epi64 (r1, r2);
+        t2 = _mm256_unpackhi_epi64 (r1, r2);
+        /* 0xd8 = 3120 base_4 */
+        r1 = _mm256_permute4x64_epi64 (t1, 0xd8);
+        r2 = _mm256_permute4x64_epi64 (t2, 0xd8);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -222,7 +222,6 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
      * lane in a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
      *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
-     * Return:   [ a0, b0, a1, b1, a4, b4, a5, b5 ]
      * Return:	 [ a0, b0, a1, b1, ..., a3, b3, a8, b8, ..., a11, b11 ]
      */
     static INLINE CONST vect_t
@@ -235,7 +234,6 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
      * lane in a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
      *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
-     * Return:   [ a2, b2, a3, b3, a6, b6, a7, b7 ]
      * Return:	 [ a4, b4, a5, b5, ..., a7, b7, a12, b12, ..., a15, b15 ]
      */
     static INLINE CONST vect_t

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -220,84 +220,120 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
     }
 
     /*
-     * Unpack and interleave 32-bit integers from the low half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a0, b0, a1, b1, a4, b4, a5, b5] int32_t
+     * Unpack and interleave 32-bit integers from the low half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a4, b4, a5, b5 ]
      */
-    static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) { return _mm256_unpacklo_epi32(a, b); }
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpacklo_epi32(a, b);
+    }
 
     /*
-     * Unpack and interleave 32-bit integers from the high half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a2, b2, a3, b3, a6, b6, a7, b7] int32_t
+     * Unpack and interleave 32-bit integers from the high half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a2, b2, a3, b3, a6, b6, a7, b7 ]
      */
-    static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) { return _mm256_unpackhi_epi32(a, b); }
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpackhi_epi32(a, b);
+    }
 
     /*
-     * Unpack and interleave 32-bit integers from the low half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a0, b0, ..., a3, b3] int32_t
+     * Unpack and interleave 32-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
      */
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-        //using Simd256_64 = Simd256<uint64_t>;
-        //Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
-        //Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
-        vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
-        return unpacklo_twice(a1, b1);
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        return _mm256_unpacklo_epi32 (t1, t2);
     }
 
     /*
-     * Unpack and interleave 32-bit integers from the high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a4, b4, ..., a7, b7] int32_t
+     * Unpack and interleave 32-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-        // using Simd256_64 = Simd256<uint64_t>;
-        // vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-        // vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        vect_t a1 = _mm256_permute4x64_epi64(a, 0xD8);
-        vect_t b1 = _mm256_permute4x64_epi64(a, 0xD8);
-        return unpackhi_twice(a1, b1);
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        return _mm256_unpackhi_epi32 (t1, t2);
     }
 
-    /* unpacklohi:
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
-     *         r2 = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     * Return: lo = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         hi = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
     static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        vect_t t1, t2;
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         /* 0xd8 = 3120 base_4 */
-        t1 = _mm256_permute4x64_epi64 (a, 0xd8);
-        t2 = _mm256_permute4x64_epi64 (b, 0xd8);
-        r1 = _mm256_unpacklo_epi32 (t1, t2);
-        r2 = _mm256_unpackhi_epi32 (t1, t2);
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        lo = _mm256_unpacklo_epi32 (t1, t2);
+        hi = _mm256_unpackhi_epi32 (t1, t2);
     }
 
-    /* pack:
+    /*
+     * Pack 32-bit integers from the even positions of a and b.
      * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
      *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
-     * Return: r1 = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
-     *         r2 = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     * Return:   [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        vect_t ta = _mm256_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm256_shuffle_epi32 (b, 0xd8);
+        vect_t t1 = _mm256_unpacklo_epi64 (ta, tb);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_permute4x64_epi64 (t1, 0xd8);
+    }
+
+    /*
+     * Pack 32-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        /* 0xd8 = 3120 base_4 */
+        vect_t ta = _mm256_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm256_shuffle_epi32 (b, 0xd8);
+        vect_t t2 = _mm256_unpackhi_epi64 (ta, tb);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_permute4x64_epi64 (t2, 0xd8);
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: even = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         odd = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        vect_t t1, t2;
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
         /* 0xd8 = 3120 base_4 */
-        r1 = _mm256_shuffle_epi32 (a, 0xd8);
-        r2 = _mm256_shuffle_epi32 (b, 0xd8);
-        t1 = _mm256_unpacklo_epi64 (r1, r2);
-        t2 = _mm256_unpackhi_epi64 (r1, r2);
+        vect_t ta = _mm256_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm256_shuffle_epi32 (b, 0xd8);
+        vect_t t1 = _mm256_unpacklo_epi64 (ta, tb);
+        vect_t t2 = _mm256_unpackhi_epi64 (ta, tb);
         /* 0xd8 = 3120 base_4 */
-        r1 = _mm256_permute4x64_epi64 (t1, 0xd8);
-        r2 = _mm256_permute4x64_epi64 (t2, 0xd8);
+        even = _mm256_permute4x64_epi64 (t1, 0xd8);
+        odd = _mm256_permute4x64_epi64 (t2, 0xd8);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -218,74 +218,111 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the low half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] int64_t
-     [b0, b1, b2, b3] int64_t
-     * Return : [a0, b0, a2, b2] int64_t
+     * Unpack and interleave 64-bit integers from the low half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a0, b0, a2, b2 ]
      */
-    static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) { return _mm256_unpacklo_epi64(a, b); }
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpacklo_epi64(a, b);
+    }
 
     /*
-     * Unpack and interleave 64-bit integers from the high half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] int64_t
-     [b0, b1, b2, b3] int64_t
-     * Return : [a1, b1, a3, b3] int64_t
+     * Unpack and interleave 64-bit integers from the high half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a1, b1, a3, b3 ]
      */
-    static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) { return _mm256_unpackhi_epi64(a, b); }
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm256_unpackhi_epi64(a, b);
+    }
 
     /*
-     * Unpack and interleave 64-bit integers from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] int64_t
-     [b0, b1, b2, b3] int64_t
-     * Return : [a0, b0, a1, b1] int64_t
+     * Unpack and interleave 64-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a0, b0, a1, b1 ]
      */
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-        vect_t a1 = shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3]
-        vect_t b1 = shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        return unpacklo_twice(a1, b1);
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        return _mm256_unpacklo_epi64 (t1, t2);
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3] int64_t
-     [b0, b1, b2, b3] int64_t
-     * Return : [a2, b2, a3, b3] int64_t
+     * Unpack and interleave 64-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a2, b2, a3, b3 ]
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-        vect_t a1 = shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-        vect_t b1 = shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-        return unpackhi_twice(a1, b1);
+        /* 0xd8 = 3120 base_4 */
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        return _mm256_unpackhi_epi64 (t1, t2);
     }
 
-    /* unpacklohi:
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
      * Args: a = [ a0, a1, a2, a3 ]
      *       b = [ b0, b1, b2, b3 ]
-     * Return: r1 = [ a0, b0, a1, b1 ]
-     *         r2 = [ a2, b2, a3, b3 ]
+     * Return: lo = [ a0, b0, a1, b1 ]
+     *         hi = [ a2, b2, a3, b3 ]
      */
     static INLINE void
-    unpacklohi (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        vect_t t1, t2;
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         /* 0xd8 = 3120 base_4 */
-        t1 = _mm256_permute4x64_epi64 (a, 0xd8);
-        t2 = _mm256_permute4x64_epi64 (b, 0xd8);
-        r1 = _mm256_unpacklo_epi64 (t1, t2);
-        r2 = _mm256_unpackhi_epi64 (t1, t2);
+        vect_t t1 = _mm256_permute4x64_epi64 (a, 0xd8);
+        vect_t t2 = _mm256_permute4x64_epi64 (b, 0xd8);
+        lo = _mm256_unpacklo_epi64 (t1, t2);
+        hi = _mm256_unpackhi_epi64 (t1, t2);
     }
 
-    /* pack:
+    /*
+     * Pack 64-bit integers from the even positions of a and b.
      * Args: a = [ a0, a1, a2, a3 ]
      *       b = [ b0, b1, b2, b3 ]
-     * Return: r1 = [ a0, a2, b0, b2 ]
-     *         r2 = [ a1, a3, b1, b3 ]
+     * Return:   [ a0, a2, b0, b2 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        vect_t t1 = _mm256_unpacklo_epi64 (a, b);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_permute4x64_epi64 (t1, 0xd8);
+    }
+
+    /*
+     * Pack 64-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return:   [ a1, a3, b1, b3 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        vect_t t2 = _mm256_unpackhi_epi64 (a, b);
+        /* 0xd8 = 3120 base_4 */
+        return _mm256_permute4x64_epi64 (t2, 0xd8);
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3 ]
+     *       b = [ b0, b1, b2, b3 ]
+     * Return: even = [ a0, a2, b0, b2 ]
+     *         odd  = [ a1, a3, b1, b3 ]
      */
     static INLINE void
-    pack (vect_t& r1, vect_t& r2, const vect_t a, const vect_t b) {
-        r1 = _mm256_unpacklo_epi64 (a, b);
-        r2 = _mm256_unpackhi_epi64 (a, b);
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        vect_t t1 = _mm256_unpacklo_epi64 (a, b);
+        vect_t t2 = _mm256_unpackhi_epi64 (a, b);
         /* 0xd8 = 3120 base_4 */
-        r1 = _mm256_permute4x64_epi64 (r1, 0xd8);
-        r2 = _mm256_permute4x64_epi64 (r2, 0xd8);
+        even = _mm256_permute4x64_epi64 (t1, 0xd8);
+        odd = _mm256_permute4x64_epi64 (t2, 0xd8);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -155,24 +155,123 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
         return _mm512_permute_pd(a, s);
     }
 
+    /*
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the low half of each 128-bit lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a2, b2, a4, b4, a6, b6 ]
+     */
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpacklo_pd(a,b);
+    }
 
     /*
-     * Unpack and interleave double-precision (64-bit) floating-point elements from the low half of each 128-bit lane in a and b,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] double
-     [b0, b1, b2, b3, b4, b5, b6, b7] double
-     * Return : [a0, b0, a2, b2, a4, b4, a6, b6] double
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the high half of each 128-bit lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, b1, a3, b3, a5, b5, a7, b7 ]
      */
-    static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) { return _mm512_unpacklo_pd(a, b); }
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpackhi_pd(a,b);
+    }
 
     /*
-     * Unpack and interleave double-precision (64-bit) floating-point elements from the high half of each 128-bit lane in a and b,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] double
-     [b0, b1, b2, b3, b4, b5, b6, b7] double
-     * Return : [a1, b1, a3, b3, a5, b5, a7, b7] double
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
      */
-    static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) { return _mm512_unpackhi_pd(a, b); }
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a)
+        vect_t tb = _mm512_permutexvar_pd (s, b)
+        return _mm512_unpacklo_pd (ta, tb);
+    }
+
+    /*
+     * Unpack and interleave double-precision (64-bit) floating-point elements
+     * from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a)
+        vect_t tb = _mm512_permutexvar_pd (s, b)
+        return _mm512_unpackhi_pd (ta, tb);
+    }
+
+    /*
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: lo = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         hi = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
+     */
+    static INLINE void
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a)
+        vect_t tb = _mm512_permutexvar_pd (s, b)
+        lo = _mm512_unpacklo_pd (ta, tb);
+        hi = _mm512_unpackhi_pd (ta, tb);
+    }
+
+    /*
+     * Pack double-precision (64-bit) floating-point elements from the even
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t lo = _mm512_unpacklo_pd (a, b);
+        return _mm512_permutexvar_pd (s, lo)
+    }
+
+    /*
+     * Pack double-precision (64-bit) floating-point elements from the odd
+     * positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t hi = _mm512_unpackhi_pd (a, b);
+        return _mm512_permutexvar_pd (s, hi)
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: even = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         odd = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        vect_t lo = _mm512_unpacklo_pd (a, b);
+        vect_t hi = _mm512_unpackhi_pd (a, b);
+        even = _mm512_permutexvar_pd (s, lo)
+        odd  = _mm512_permutexvar_pd (s, hi)
+    }
 
     /*
      * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -188,9 +188,9 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      */
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
-        vect_t ta = _mm512_permutexvar_pd (s, a)
-        vect_t tb = _mm512_permutexvar_pd (s, b)
+        __m512i s = _mm512_loadu_si512 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a);
+        vect_t tb = _mm512_permutexvar_pd (s, b);
         return _mm512_unpacklo_pd (ta, tb);
     }
 
@@ -203,9 +203,9 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
-        vect_t ta = _mm512_permutexvar_pd (s, a)
-        vect_t tb = _mm512_permutexvar_pd (s, b)
+        __m512i s = _mm512_loadu_si512 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a);
+        vect_t tb = _mm512_permutexvar_pd (s, b);
         return _mm512_unpackhi_pd (ta, tb);
     }
 
@@ -220,9 +220,9 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
     static INLINE void
     unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
-        vect_t ta = _mm512_permutexvar_pd (s, a)
-        vect_t tb = _mm512_permutexvar_pd (s, b)
+        __m512i s = _mm512_loadu_si512 (permute_idx);
+        vect_t ta = _mm512_permutexvar_pd (s, a);
+        vect_t tb = _mm512_permutexvar_pd (s, b);
         lo = _mm512_unpacklo_pd (ta, tb);
         hi = _mm512_unpackhi_pd (ta, tb);
     }
@@ -236,9 +236,9 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      */
     static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t lo = _mm512_unpacklo_pd (a, b);
-        return _mm512_permutexvar_pd (s, lo)
+        return _mm512_permutexvar_pd (s, lo);
     }
 
     /*
@@ -250,9 +250,9 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
      */
     static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t hi = _mm512_unpackhi_pd (a, b);
-        return _mm512_permutexvar_pd (s, hi)
+        return _mm512_permutexvar_pd (s, hi);
     }
 
     /*
@@ -266,11 +266,11 @@ template <> struct Simd512_impl<true, false, true, 8> : public Simd512fp_base {
     static INLINE void
     pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
-        __m512i s = _mm512_loadu_epi64 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t lo = _mm512_unpacklo_pd (a, b);
         vect_t hi = _mm512_unpackhi_pd (a, b);
-        even = _mm512_permutexvar_pd (s, lo)
-        odd  = _mm512_permutexvar_pd (s, hi)
+        even = _mm512_permutexvar_pd (s, lo);
+        odd  = _mm512_permutexvar_pd (s, hi);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -185,8 +185,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        vect_t ta = _mm512_permutexvar_ps (s, a)
-        vect_t tb = _mm512_permutexvar_ps (s, b)
+        vect_t ta = _mm512_permutexvar_ps (s, a);
+        vect_t tb = _mm512_permutexvar_ps (s, b);
         return _mm512_unpacklo_ps (ta, tb);
     }
 
@@ -200,8 +200,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        vect_t ta = _mm512_permutexvar_ps (s, a)
-        vect_t tb = _mm512_permutexvar_ps (s, b)
+        vect_t ta = _mm512_permutexvar_ps (s, a);
+        vect_t tb = _mm512_permutexvar_ps (s, b);
         return _mm512_unpackhi_ps (ta, tb);
     }
 
@@ -217,8 +217,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        vect_t ta = _mm512_permutexvar_ps (s, a)
-        vect_t tb = _mm512_permutexvar_ps (s, b)
+        vect_t ta = _mm512_permutexvar_ps (s, a);
+        vect_t tb = _mm512_permutexvar_ps (s, b);
         lo = _mm512_unpacklo_ps (ta, tb);
         hi = _mm512_unpackhi_ps (ta, tb);
     }
@@ -234,7 +234,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
         int32_t permute_idx[16] = { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 };
         __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t t1 = _mm512_shuffle_ps (a, b, 0x88); /* 0x88 = 2020 base_4 */
-        return _mm512_permutexvar_ps (s, t1)
+        return _mm512_permutexvar_ps (s, t1);
     }
 
     /*
@@ -248,7 +248,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
         int32_t permute_idx[16] = { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 };
         __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t t2 = _mm512_shuffle_ps (a, b, 0xdd); /* 0xdd = 3131 base_4 */
-        return _mm512_permutexvar_ps (s, t2)
+        return _mm512_permutexvar_ps (s, t2);
     }
 
     /*
@@ -265,8 +265,8 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
         __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t t1 = _mm512_shuffle_ps (a, b, 0x88); /* 0x88 = 2020 base_4 */
         vect_t t2 = _mm512_shuffle_ps (a, b, 0xdd); /* 0xdd = 3131 base_4 */
-        even = _mm512_permutexvar_ps (s, t1)
-        odd = _mm512_permutexvar_ps (s, t2)
+        even = _mm512_permutexvar_ps (s, t1);
+        odd = _mm512_permutexvar_ps (s, t2);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -231,13 +231,10 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      * Return:   [ a0, a2, ..., a12, a14, b0, b2, ..., b12, b14 ]
      */
     static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
-        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        int32_t permute_idx[16] = { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        /* 0xd8 = 3120 base_4 */
-        vect_t ta = _mm512_shuffle_ps (a, 0xd8);
-        vect_t tb = _mm512_shuffle_ps (b, 0xd8);
-        vect_t lo = _mm512_unpacklo_ps (ta, tb);
-        return _mm512_permutexvar_ps (s, lo)
+        vect_t t1 = _mm512_shuffle_ps (a, b, 0x88); /* 0x88 = 2020 base_4 */
+        return _mm512_permutexvar_ps (s, t1)
     }
 
     /*
@@ -248,13 +245,10 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      * Return:   [ a1, a3, ..., a13, a15, b1, b3, ..., b13, b15 ]
      */
     static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
-        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        int32_t permute_idx[16] = { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        /* 0xd8 = 3120 base_4 */
-        vect_t ta = _mm512_shuffle_ps (a, 0xd8);
-        vect_t tb = _mm512_shuffle_ps (b, 0xd8);
-        vect_t hi = _mm512_unpackhi_ps (ta, tb);
-        return _mm512_permutexvar_ps (s, hi)
+        vect_t t2 = _mm512_shuffle_ps (a, b, 0xdd); /* 0xdd = 3131 base_4 */
+        return _mm512_permutexvar_ps (s, t2)
     }
 
     /*
@@ -267,15 +261,12 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      */
     static INLINE void
     pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
-        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        int32_t permute_idx[16] = { 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15 };
         __m512i s = _mm512_loadu_si512 (permute_idx);
-        /* 0xd8 = 3120 base_4 */
-        vect_t ta = _mm512_shuffle_ps (a, 0xd8);
-        vect_t tb = _mm512_shuffle_ps (b, 0xd8);
-        vect_t lo = _mm512_unpacklo_ps (ta, tb);
-        vect_t hi = _mm512_unpackhi_ps (ta, tb);
-        even = _mm512_permutexvar_ps (s, lo)
-        odd = _mm512_permutexvar_ps (s, hi)
+        vect_t t1 = _mm512_shuffle_ps (a, b, 0x88); /* 0x88 = 2020 base_4 */
+        vect_t t2 = _mm512_shuffle_ps (a, b, 0xdd); /* 0xdd = 3131 base_4 */
+        even = _mm512_permutexvar_ps (s, t1)
+        odd = _mm512_permutexvar_ps (s, t2)
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -184,7 +184,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      */
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t ta = _mm512_permutexvar_ps (s, a)
         vect_t tb = _mm512_permutexvar_ps (s, b)
         return _mm512_unpacklo_ps (ta, tb);
@@ -199,7 +199,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      */
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t ta = _mm512_permutexvar_ps (s, a)
         vect_t tb = _mm512_permutexvar_ps (s, b)
         return _mm512_unpackhi_ps (ta, tb);
@@ -216,7 +216,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static INLINE void
     unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         vect_t ta = _mm512_permutexvar_ps (s, a)
         vect_t tb = _mm512_permutexvar_ps (s, b)
         lo = _mm512_unpacklo_ps (ta, tb);
@@ -232,7 +232,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      */
     static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         /* 0xd8 = 3120 base_4 */
         vect_t ta = _mm512_shuffle_ps (a, 0xd8);
         vect_t tb = _mm512_shuffle_ps (b, 0xd8);
@@ -249,7 +249,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
      */
     static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         /* 0xd8 = 3120 base_4 */
         vect_t ta = _mm512_shuffle_ps (a, 0xd8);
         vect_t tb = _mm512_shuffle_ps (b, 0xd8);
@@ -268,7 +268,7 @@ template <> struct Simd512_impl<true, false, true, 4> : public Simd512fp_base {
     static INLINE void
     pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
         int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
-        __m512i s = _mm512_loadu_epi32 (permute_idx);
+        __m512i s = _mm512_loadu_si512 (permute_idx);
         /* 0xd8 = 3120 base_4 */
         vect_t ta = _mm512_shuffle_ps (a, 0xd8);
         vect_t tb = _mm512_shuffle_ps (b, 0xd8);

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -224,64 +224,129 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd512i_base {
                     conv.t[((s>>56) & 0x0000000F)], conv.t[((s>>56) & 0x000000F0)]);
     }
 
+    /*
+     * Unpack and interleave 32-bit integers from the low half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:	 [ a0, b0, a1, b1, a4, b4, a5, b5, ..., a12, b12, a13, b13 ]
+     */
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpacklo_epi32(a,b);
+    }
 
     /*
-     * Unpack and interleave 32-bit integers from the low half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a0, b0, a1, b1, a4, b4, a5, b5] int32_t
+     * Unpack and interleave 32-bit integers from the high half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:	 [ a2, b2, a3, b3, a6, b6, a7, b7, ..., a14, b14, a15, b15 ]
      */
-    //static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) { return _mm256_unpacklo_epi32(a, b); }
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpackhi_epi32(a,b);
+    }
 
     /*
-     * Unpack and interleave 32-bit integers from the high half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a2, b2, a3, b3, a6, b6, a7, b7] int32_t
+     * Unpack and interleave 32-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:   [ a0, b0, a1, b1, ..., a6, b7, a7, b7 ]
      */
-    //static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) { return _mm256_unpackhi_epi32(a, b); }
+    static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi32 (s, a)
+        vect_t tb = _mm512_permutexvar_epi32 (s, b)
+        return _mm512_unpacklo_epi32 (ta, tb);
+    }
 
     /*
-     * Unpack and interleave 32-bit integers from the low half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a0, b0, ..., a3, b3] int32_t
+     * Unpack and interleave 32-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:   [ a8, b8, a9, b9, ..., a14, b14, a15, b15 ]
      */
-    /*static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-      using Simd256_64 = Simd256<uint64_t>;
-      vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4 so a -> [a0,a2,a1,a3] uint64
-      vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-      return unpacklo_twice(a1, b1);
-      }
-      */
+    static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi32 (s, a)
+        vect_t tb = _mm512_permutexvar_epi32 (s, b)
+        return _mm512_unpackhi_epi32 (ta, tb);
+    }
+
     /*
-     * Unpack and interleave 32-bit integers from the high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a4, b4, ..., a7, b7] int32_t
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: lo = [ a0, b0, a1, b1, ..., a6, b7, a7, b7 ]
+     *         hi = [ a8, b8, a9, b9, ..., a14, b14, a15, b15 ]
      */
-    /*static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-      using Simd256_64 = Simd256<uint64_t>;
-      vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-      vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-      return unpackhi_twice(a1, b1);
-      }
-      */
+    static INLINE void
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15  };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi32 (s, a)
+        vect_t tb = _mm512_permutexvar_epi32 (s, b)
+        lo = _mm512_unpacklo_epi32 (ta, tb);
+        hi = _mm512_unpackhi_epi32 (ta, tb);
+    }
+
     /*
-     * Unpack and interleave 32-bit integers from the low then high half of a and b, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[a0, b0, ..., a3, b3] int32_t
-     *			[a4, b4, ..., a7, b7] int32_t
+     * Pack 32-bit integers from the even positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:   [ a0, a2, ..., a12, a14, b0, b2, ..., b12, b14 ]
      */
-    /*static INLINE CONST void unpacklohi(vect_t& s1, vect_t& s2, const vect_t a, const vect_t b) {
-      using Simd256_64 = Simd256<uint64_t>;
-      vect_t a1 = Simd256_64::template shuffle<0xD8>(a); // 0xD8 = 3120 base_4
-      vect_t b1 = Simd256_64::template shuffle<0xD8>(b); // 0xD8 = 3120 base_4
-      s1 = unpacklo_twice(a1, b1);
-      s2 = unpackhi_twice(a1, b1);
-      }
-      */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        vect_t s = loadu (permute_idx);
+        /* 0xd8 = 3120 base_4 */
+        vect_t ta = _mm512_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm512_shuffle_epi32 (b, 0xd8);
+        vect_t lo = _mm512_unpacklo_epi32 (ta, tb);
+        return _mm512_permutexvar_epi32 (s, lo)
+    }
+
+    /*
+     * Pack 32-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return:   [ a1, a3, ..., a13, a15, b1, b3, ..., b13, b15 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        vect_t s = loadu (permute_idx);
+        /* 0xd8 = 3120 base_4 */
+        vect_t ta = _mm512_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm512_shuffle_epi32 (b, 0xd8);
+        vect_t hi = _mm512_unpackhi_epi32 (ta, tb);
+        return _mm512_permutexvar_epi32 (s, hi)
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, ..., a13, a14, a15 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, ..., b13, b14, b15 ]
+     * Return: even = [ a0, a2, ..., a12, a14, b0, b2, ..., b12, b14 ]
+     *         odd = [ a1, a3, ..., a13, a15, b1, b3, ..., b13, b15 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        int32_t permute_idx[16] = { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 };
+        vect_t s = loadu (permute_idx);
+        /* 0xd8 = 3120 base_4 */
+        vect_t ta = _mm512_shuffle_epi32 (a, 0xd8);
+        vect_t tb = _mm512_shuffle_epi32 (b, 0xd8);
+        vect_t lo = _mm512_unpacklo_epi32 (ta, tb);
+        vect_t hi = _mm512_unpackhi_epi32 (ta, tb);
+        even = _mm512_permutexvar_epi32 (s, lo)
+        odd = _mm512_permutexvar_epi32 (s, hi)
+    }
+
     /*TODO BLEND
      * Blend packed 32-bit integers from a and b using control mask imm8, and store the results in dst.
      * Args   :	[a0, ..., a7] int32_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -249,8 +249,8 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
         vect_t s = loadu (permute_idx);
-        vect_t ta = _mm512_permutexvar_epi64 (s, a)
-        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        vect_t ta = _mm512_permutexvar_epi64 (s, a);
+        vect_t tb = _mm512_permutexvar_epi64 (s, b);
         return _mm512_unpacklo_epi64 (ta, tb);
     }
 
@@ -263,8 +263,8 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
         vect_t s = loadu (permute_idx);
-        vect_t ta = _mm512_permutexvar_epi64 (s, a)
-        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        vect_t ta = _mm512_permutexvar_epi64 (s, a);
+        vect_t tb = _mm512_permutexvar_epi64 (s, b);
         return _mm512_unpackhi_epi64 (ta, tb);
     }
 
@@ -280,8 +280,8 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
         int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
         vect_t s = loadu (permute_idx);
-        vect_t ta = _mm512_permutexvar_epi64 (s, a)
-        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        vect_t ta = _mm512_permutexvar_epi64 (s, a);
+        vect_t tb = _mm512_permutexvar_epi64 (s, b);
         lo = _mm512_unpacklo_epi64 (ta, tb);
         hi = _mm512_unpackhi_epi64 (ta, tb);
     }
@@ -296,7 +296,7 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
         int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
         vect_t s = loadu (permute_idx);
         vect_t lo = _mm512_unpacklo_epi64 (a, b);
-        return _mm512_permutexvar_epi64 (s, lo)
+        return _mm512_permutexvar_epi64 (s, lo);
     }
 
     /*
@@ -309,7 +309,7 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
         int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
         vect_t s = loadu (permute_idx);
         vect_t hi = _mm512_unpackhi_epi64 (a, b);
-        return _mm512_permutexvar_epi64 (s, hi)
+        return _mm512_permutexvar_epi64 (s, hi);
     }
 
     /*
@@ -326,8 +326,8 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
         vect_t s = loadu (permute_idx);
         vect_t lo = _mm512_unpacklo_epi64 (a, b);
         vect_t hi = _mm512_unpackhi_epi64 (a, b);
-        even = _mm512_permutexvar_epi64 (s, lo)
-        odd  = _mm512_permutexvar_epi64 (s, hi)
+        even = _mm512_permutexvar_epi64 (s, lo);
+        odd  = _mm512_permutexvar_epi64 (s, hi);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -217,76 +217,117 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the low half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, a4, a5, a6, a7] int64_t
-     * Return : [a0, b0, a2, b2, a4, b4, a6, b6] int64_t
+     * Unpack and interleave 64-bit integers from the low half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a2, b2, a4, b4, a6, b6 ]
      */
-    static INLINE CONST vect_t unpacklo_twice(const vect_t a, const vect_t b) {
-        //std::cerr<<"unpacklo_twice simd512_int64"<<std::endl;
-        return _mm512_unpacklo_epi64(a, b); }
+    static INLINE CONST vect_t
+    unpacklo_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpacklo_epi64(a, b);
+    }
 
     /*
-     * Unpack and interleave 64-bit integers from the high half of a and b within 128-bit lanes, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, a4, a5, a6, a7] int64_t
-     * Return : [a0, b0, a2, b2, a4, b4, a6, b6] int64_t
+     * Unpack and interleave 64-bit integers from the high half of each 128-bit
+     * lane in a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, b1, a3, b3, a5, b5, a7, b7 ]
      */
-    static INLINE CONST vect_t unpackhi_twice(const vect_t a, const vect_t b) {
-        //std::cerr<<"unpackhi_twice simd512_int64"<<std::endl;
-        return _mm512_unpackhi_epi64(a, b); }
+    static INLINE CONST vect_t
+    unpackhi_intrinsic (const vect_t a, const vect_t b) {
+        return _mm512_unpackhi_epi64(a, b);
+    }
 
     /*
-     * Unpack and interleave 64-bit integers from the low half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, b4, b5, b6, b7] int64_t
-     * Return : [a0, b0, a1, b1, a2, b2, a3, b3] int64_t
+     * Unpack and interleave 64-bit integers from the low half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, b0, a1, b1, a2, b2, a3, b3 ]
      */
-
     static INLINE CONST vect_t unpacklo(const vect_t a, const vect_t b) {
-        //std::cerr<<"unpacklo simd512_int64"<<std::endl;
-        __m256i a1 = _mm512_castsi512_si256(a); // a1 = [a0, a1, a2, a3]
-        __m256i b1 = _mm512_castsi512_si256(b); // b1 = [b0, b1, b2, b3]
-        __m256i a2 = _mm256_permute4x64_epi64(a1, 0xD8); // a2 = [a0, a2, a1, a3] (0xD8 a1 <-> a2)
-        __m256i b2 = _mm256_permute4x64_epi64(b1, 0xD8); // b2 = [b0, b2, b1, b3] (0xD8 b1 <-> b2)
-        __m256i low = _mm256_unpacklo_epi64(a2, b2); // low = [a0, bo, a1, b1]
-        __m256i high = _mm256_unpackhi_epi64(a2, b2); // high = [a2, b2, a3, b3]
-        __m512i res = _mm512_castsi256_si512(low);
-        res = _mm512_inserti64x4(res, high, 1);
-        return res;
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi64 (s, a)
+        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        return _mm512_unpacklo_epi64 (ta, tb);
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the high half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, b4, b5, b6, b7] int64_t
-     * Return : [a4, b4, a5, b5, a6, b6, a7, b7] int64_t
+     * Unpack and interleave 64-bit integers from the high half of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
-
     static INLINE CONST vect_t unpackhi(const vect_t a, const vect_t b) {
-        //std::cerr<<"unpackhi simd512_int64"<<std::endl;
-        __m256i a1 = _mm512_extracti64x4_epi64(a,1); // a1 = [a4, a5, a6, a7]
-        __m256i b1 = _mm512_extracti64x4_epi64(b,1); // b1 = [b4, b5, b6, b7]
-        __m256i a2 = _mm256_permute4x64_epi64(a1, 0xD8); // a2 = [a4, a6, a5, a7] (0xD8 a5 <-> a6)
-        __m256i b2 = _mm256_permute4x64_epi64(b1, 0xD8); // b2 = [b4, b6, b5, b7] (0xD8 b5 <-> b6)
-        __m256i low = _mm256_unpacklo_epi64(a2, b2); // low = [a0, bo, a1, b1]
-        __m256i high = _mm256_unpackhi_epi64(a2, b2); // high = [a2, b2, a3, b3]
-        __m512i res = _mm512_castsi256_si512(low);
-        res = _mm512_inserti64x4(res, high, 1);
-        return res;
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi64 (s, a)
+        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        return _mm512_unpackhi_epi64 (ta, tb);
     }
 
     /*
-     * Unpack and interleave 64-bit integers from the low then high half of a and b, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, b4, b5, b6, b7] int64_t
-     * Return : [a0, b0, a1, b1, a2, b2, a3, b3] int64_t
-     *		   [a4, b4, a5, b5, a6, b6, a7, b7] int64_t
+     * Perform unpacklo and unpackhi with a and b and store the results in lo
+     * and hi.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: lo = [ a0, b0, a1, b1, a2, b2, a3, b3 ]
+     *         hi = [ a4, b4, a5, b5, a6, b6, a7, b7 ]
      */
+    static INLINE void
+    unpacklohi (vect_t& lo, vect_t& hi, const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 4, 1, 5, 2, 6, 3, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t ta = _mm512_permutexvar_epi64 (s, a)
+        vect_t tb = _mm512_permutexvar_epi64 (s, b)
+        lo = _mm512_unpacklo_epi64 (ta, tb);
+        hi = _mm512_unpackhi_epi64 (ta, tb);
+    }
 
-    static INLINE void unpacklohi(vect_t& l, vect_t& h, const vect_t a, const vect_t b) {
-        l = unpacklo(a, b);
-        h = unpackhi(a, b);
+    /*
+     * Pack 64-bit integers from the even positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     */
+    static INLINE CONST vect_t pack_even (const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t lo = _mm512_unpacklo_epi64 (a, b);
+        return _mm512_permutexvar_epi64 (s, lo)
+    }
+
+    /*
+     * Pack 64-bit integers from the odd positions of a and b.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return:   [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE CONST vect_t pack_odd (const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t hi = _mm512_unpackhi_epi64 (a, b);
+        return _mm512_permutexvar_epi64 (s, hi)
+    }
+
+    /*
+     * Perform pack_even and pack_odd with a and b and store the results in even
+     * and odd.
+     * Args: a = [ a0, a1, a2, a3, a4, a5, a6, a7 ]
+     *       b = [ b0, b1, b2, b3, b4, b5, b6, b7 ]
+     * Return: even = [ a0, a2, a4, a6, b0, b2, b4, b6 ]
+     *         odd = [ a1, a3, a5, a7, b1, b3, b5, b7 ]
+     */
+    static INLINE void
+    pack (vect_t& even, vect_t& odd, const vect_t a, const vect_t b) {
+        int64_t permute_idx[8] = { 0, 2, 4, 6, 1, 3, 5, 7 };
+        vect_t s = loadu (permute_idx);
+        vect_t lo = _mm512_unpacklo_epi64 (a, b);
+        vect_t hi = _mm512_unpackhi_epi64 (a, b);
+        even = _mm512_permutexvar_epi64 (s, lo)
+        odd  = _mm512_permutexvar_epi64 (s, hi)
     }
 
     /*

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -198,6 +198,59 @@ test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
     return res;
 }
 
+template <class Simd, class RScal, class...AScal, class RSimd, class...ASimd>
+typename enable_if<sizeof...(AScal) == sizeof...(ASimd), bool>::type
+test_vop_ri2 (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname)
+{
+    using Element = typename Simd::scalar_t;
+    using ScalVect = vector<Element>;
+    using SimdVect = typename Simd::vect_t;
+    constexpr size_t SimdVectSize = Simd::vect_size;
+    constexpr size_t arity = sizeof...(AScal);
+
+    /* input vectors */
+    vector<ScalVect> inputs (arity, ScalVect(SimdVectSize));
+    for (auto &iv: inputs)
+        generate_random_vector (iv);
+
+    /* output vectors */
+    ScalVect out_scal(SimdVectSize), out_simd(SimdVectSize);
+
+    /* compute with scalar function */
+    function<RScal(AScal...)> fscal = FScal;
+    out_scal = fscal (inputs[0], inputs[1]);
+
+    /* compute with SIMD function */
+    array<SimdVect, arity> simd_in;
+    function<RSimd(ASimd...)> fsimd = FSimd;
+    for (size_t i = 0; i < arity; i++)
+        simd_in[i] = Simd::loadu (inputs[i].data());
+
+    SimdVect simd_out = eval_func_on_array (fsimd, simd_in);
+    Simd::storeu (out_simd.data(), simd_out);
+
+    /* comparison */
+    auto eq = check_eq<Element>;
+    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
+
+    /* print result line */
+    cout << Simd::type_string() << "<" << TypeName<Element>() << ">::" << fname
+         << " " << string (60 - fname.size() - strlen(TypeName<Element>()), '.')
+         << " " << (res ? "success" : "failure") << endl;
+
+    /* in case of error, print all input and output values */
+    if(!res) {
+        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
+        for (size_t i = 0; i < arity; i++) {
+            cout << "input_" << i << ": " << inputs[i] << endl;
+        }
+        cout << "out_scal: " << out_scal << endl;
+        cout << "out_simd: " << out_simd << endl;
+        cout << string (80, '-') << endl;
+    }
+    return res;
+}
+
 /******************************************************************************/
 /* Scalar functions for comparisons *******************************************/
 /******************************************************************************/
@@ -210,6 +263,7 @@ template <class Element>
 struct ScalFunctions<Element,
                     typename enable_if<is_floating_point<Element>::value>::type>
 {
+    using VectElement = vector<Element>;
     static Element zero () {
         return 0.0;
     }
@@ -307,6 +361,30 @@ struct ScalFunctions<Element,
     static Element eq (Element x1, Element x2) {
         return (x1==x2)?NAN:0;
     }
+    static VectElement unpacklo (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i % 2 ? b[i/2] : a[i/2]);
+        return r;
+    }
+    static VectElement unpackhi (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i % 2 ? b[(a.size()+i)/2] : a[(a.size()+i)/2]);
+        return r;
+    }
+    static VectElement pack_even (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i < a.size()/2 ? a[2*i] : b[2*i-a.size()]);
+        return r;
+    }
+    static VectElement pack_odd (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i < a.size()/2 ? a[1+2*i] : b[1+2*i-a.size()]);
+        return r;
+    }
 };
 
 /* for integral element */
@@ -314,6 +392,7 @@ template <class Element>
 struct ScalFunctions<Element,
                     typename enable_if<is_integral<Element>::value>::type>
 {
+    using VectElement = vector<Element>;
     static Element zero () {
         return 0;
     }
@@ -457,6 +536,30 @@ struct ScalFunctions<Element,
     static Element eq (Element x1, Element x2) {
         return (x1==x2)?-1:0;
     }
+    static VectElement unpacklo (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i % 2 ? b[i/2] : a[i/2]);
+        return r;
+    }
+    static VectElement unpackhi (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i % 2 ? b[(a.size()+i)/2] : a[(a.size()+i)/2]);
+        return r;
+    }
+    static VectElement pack_even (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i < a.size()/2 ? a[2*i] : b[2*i-a.size()]);
+        return r;
+    }
+    static VectElement pack_odd (VectElement a, VectElement b) {
+        VectElement r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = (i < a.size()/2 ? a[1+2*i] : b[1+2*i-a.size()]);
+        return r;
+    }
 };
 
 /******************************************************************************/
@@ -465,6 +568,8 @@ struct ScalFunctions<Element,
 
 #define TEST_ONE_OP(name) \
     btest &= test_op<simd> (simd::name, Scal::name, #name);
+#define TEST_ONE_VOP_RI2(name) \
+    btest &= test_vop_ri2<simd> (simd::name, Scal::name, #name);
 
 /* for floating point element */
 template<class simd, class Element>
@@ -499,6 +604,10 @@ test_impl () {
     TEST_ONE_OP (greater);
     TEST_ONE_OP (greater_eq);
     TEST_ONE_OP (eq);
+    TEST_ONE_VOP_RI2 (unpacklo);
+    TEST_ONE_VOP_RI2 (unpackhi);
+    TEST_ONE_VOP_RI2 (pack_even);
+    TEST_ONE_VOP_RI2 (pack_odd);
 
     return btest;
 }
@@ -547,6 +656,10 @@ test_impl () {
     TEST_ONE_OP (template srl<11>);
     TEST_ONE_OP (template sll<2>);
     TEST_ONE_OP (template sll<13>);
+    TEST_ONE_VOP_RI2 (unpacklo);
+    TEST_ONE_VOP_RI2 (unpackhi);
+    TEST_ONE_VOP_RI2 (pack_even);
+    TEST_ONE_VOP_RI2 (pack_odd);
 
     return btest;
 }


### PR DESCRIPTION
This PR proposes to add two new method to the Simd structs: unpacklohi and pack. These two methods are currently implemented in `linbox/algorithms/polynomial-matrix/fft-simd.h` in LinBox. The input and output of theses two methods are:

```
unpacklohi:
      Input (with n = Simd::vect_size):
             a = [ a0, a1, ..., an-1 ]
             b = [ b0, b1, ..., bn-1 ]
      Ouput (with l = n/2 = Simd::vect_size/2):
            r1 = [ a0, b0, a1, b1, ..., al-1, bl-1 ]
            r2 = [ al, bl, al+1, bl+1, ..., an-1, bn-1 ]
```

```
pack:
     Input (with n = Simd::vect_size):
            a = [ a0, a1, ..., an-1 ]
            b = [ b0, b1, ..., bn-1 ]
     Ouput (with l = n/2 = Simd::vect_size/2):
            r1 = [ a0, a2, ..., an-2, b0, b2, ..., bn-2 ]
            r2 = [ a1, a3, ..., an-1, b1, b3, ..., bn-1 ]
```


Note that:
- the semantic of unpacklohi is different from the semantic of unpacklo and unpackhi from the intrinsics but follows the semantic of unpacklo and unpackhi in the simd structs of fflas (when these methods exist).
- unpacklohi and pack are not implement for Simd512 as I have no way of testing this case




When this PR is accepted, I will remove similar code from `linbox/algorithms/polynomial-matrix/fft-simd.h` in LinBox and update the rest of the fft code accordingly.
