### PR TITLE
Improve testing of Simd structs + some fixes

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -266,11 +266,12 @@ template <> struct Simd128_impl<true, false, true, 8> {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using mask,
-     * and store the results in dst.
-     * Args   : [a0, a1] double
-     [b0, b1] double
-     * Return : [mask[63]?a0:b0, mask[127]?a1:b1] double
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using the vector mask as control.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     *       mask
+     * Return: [ mask[63] ? a0 : b0, mask[127] ? a1 : b1 ]
      */
     static INLINE CONST vect_t blendv(const vect_t a, const vect_t b, const vect_t mask) {
         return _mm_blendv_pd(a, b, mask);

--- a/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_double.inl
@@ -253,11 +253,12 @@ template <> struct Simd128_impl<true, false, true, 8> {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * Args   : [a0, a1] double
-     [b0, b1] double
-     * Return : [s[0]?a0:b0, s[1]?a1:b1] double
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, a1 ]
+     *       s = a 2-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, s[1] ? a1 : b1 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -271,11 +271,12 @@ template <> struct Simd128_impl<true, false, true, 4> {
     }
 
     /*
-     * Blend packed single-precision (32-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3] float
-     [b0, b1, b2, b3] float
-     * Return : [s[0]?a0:b0,   , s[3]?a3:b3] float
+     * Blend packed single-precision (32-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, ..., a3 ]
+     *       b = [ b0, ..., b3 ]
+     *       s = a 4-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[3] ? a3 : b3 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_float.inl
@@ -284,11 +284,12 @@ template <> struct Simd128_impl<true, false, true, 4> {
     }
 
     /*
-     * Blend packed single-precision (32-bit) floating-point elements from a and b using mask, and store the results in dst.
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3] float
-     [b0, b1, b2, b3] float
-     * Return : [mask[31]?a0:b0,   , mask[127]?a3:b3] float
+     * Blend packed single-precision (32-bit) floating-point elements from a and
+     * b using the vector mask as control.
+     * Args: a = [ a0, ..., a3 ]
+     *       b = [ b0, ..., b3 ]
+     *       mask
+     * Return: [ mask[31] ? a0 : b0, ..., mask[127] ? a3 : b3 ]
      */
     static INLINE CONST vect_t blendv(const vect_t a, const vect_t b, const vect_t mask) {
         return _mm_blendv_ps(a, b, mask);

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int16.inl
@@ -303,10 +303,11 @@ template <> struct Simd128_impl<true, true, true, 2> : public Simd128i_base {
     }
 
     /*
-     * Blend packed 16-bit integers from a and b using control mask imm8, and store the results in dst.
-     * Args   :	[a0, ..., a7] int16_t
-     [b0, ..., b7] int16_t
-     * Return :	[s[0]?a0:b0,   , s[7]?a7:b7] int16_t
+     * Blend 16-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       s = a 8-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[7] ? a7 : b7 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -749,7 +749,7 @@ template <> struct Simd128_impl<true, true, false, 8> : public Simd128_impl<true
 
     static INLINE CONST vect_t fmsubx(const vect_t c, const vect_t a, const vect_t b) { return sub(mulx(a, b), c); }
 
-    static INLINE CONST vect_t fmsubxin(vect_t c, const vect_t a, const vect_t b) { return c = fmsubx(c, a, b); }
+    static INLINE vect_t fmsubxin(vect_t &c, const vect_t a, const vect_t b) { return c = fmsubx(c, a, b); }
 
     /*
      * Horizontally add 64-bits elements of a.

--- a/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd128_int64.inl
@@ -307,17 +307,29 @@ template <> struct Simd128_impl<true, true, true, 8> : public Simd128i_base {
     }
 
     /*
-     * Blend packed 64-bit integers from a and b using control mask imm8, and store the results in dst.
-     * Args   : [a0, a1] int64_t
-     [b0, b1] int64_t
-     * Return : [s[0]?a0:b0, s[1]?a1:b1] int64_t
+     * Blend 64-bit integers from a and b using control mask s.
+     * Args: a = [ a0, a1 ]
+     *       b = [ b0, b1 ]
+     *       s = a 2-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, s[1] ? a1 : b1 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {
-        // _mm_blend_epi16 is faster than _mm_blend_epi32 and require SSE4.1 instead of AVX2
-        // We have to transform s = [d1 d0]_base2 to s1 = [d1 d1 d1 d1 d0 d0 d0 d0]_base2
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+        /* If we have AVX2, we can use _mm_blend_epi32, which is faster.
+         * We need to transform s = [d1 d0]_base2
+         * into s1 = [d1 d1 d0 d0]_base2
+         */
+        constexpr uint8_t s1 = (s & 0x1) * 3 + (((s & 0x2) << 1)*3);
+        return _mm_blend_epi32(a, b, s1);
+#else
+        /* If we only have SSE4.1, we need to use _mm_blend_epi16.
+         * We need to transform s = [d1 d0]_base2
+         * into s1 = [d1 d1 d1 d1 d0 d0 d0 d0]_base2
+         */
         constexpr uint8_t s1 = (s & 0x1) * 15 + ((s & 0x2) << 3) * 15;
         return _mm_blend_epi16(a, b, s1);
+#endif
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -331,11 +331,12 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using mask,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3] double
-     [b0, b1, b2, b3] double
-     * Return : [mask[31]?a0:b0, ..., mask[255]?a3:b3] double
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using the vector mask as control.
+     * Args: a = [ a0, ..., a3 ]
+     *       b = [ b0, ..., b3 ]
+     *       mask
+     * Return: [ mask[63] ? a0 : b0, ..., mask[255] ? a3 : b3 ]
      */
     static INLINE CONST vect_t blendv(const vect_t a, const vect_t b, const vect_t mask) {
         return _mm256_blendv_pd(a, b, mask);

--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -318,11 +318,12 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3] double
-     [b0, b1, b2, b3] double
-     * Return : [s[0]?a0:b0, ..., s[3]?a3:b3] double
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, ..., a3 ]
+     *       b = [ b0, ..., b3 ]
+     *       s = a 4-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[3] ? a3 : b3 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -338,11 +338,12 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
     }
 
     /*
-     * Blend packed single-precision (32-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * Args   :	[a0, ..., a7] float
-     [b0, ..., b7] float
-     * Return :	[s[0]?a0:b0, ..., s[7]?a7:b7] float
+     * Blend packed single-precision (32-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       s = a 8-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[7] ? a7 : b7 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_float.inl
@@ -351,11 +351,12 @@ template <> struct Simd256_impl<true, false, true, 4> : public Simd256fp_base {
     }
 
     /*
-     * Blend packed single-precision (32-bit) floating-point elements from a and b using mask,
-     * and store the results in dst.
-     * Args   :	[a0, ..., a7] float
-     [b0, ..., b7] float
-     * Return : [mask[31]?a0:b0, ..., mask[255]?a7:b7] float
+     * Blend packed single-precision (32-bit) floating-point elements from a and
+     * b using the vector mask as control.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       mask
+     * Return: [ mask[31] ? a0 : b0, ..., mask[255] ? a7 : b7 ]
      */
     static INLINE CONST vect_t blendv(const vect_t a, const vect_t b, const vect_t mask) {
         return _mm256_blendv_ps(a, b, mask);

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int16.inl
@@ -356,14 +356,30 @@ template <> struct Simd256_impl<true, true, true, 2> : public Simd256i_base {
     }
 
     /*
-     * Blend packed 16-bit integers from a and b in each 128 lane using control mask imm8, and store the results in dst.
-     * Args   :	[a0, ..., a15] int16_t
-     [b0, ..., b15] int16_t
-     * Return :	[s[0]?a0:b0,   , s[15]?a15:b15] int16_t
+     * Blend 16-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a15 ]
+     *       b = [ b0, ..., b15 ]
+     *       s = a 16-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[15] ? a15 : b15 ]
      */
-    template<uint8_t s>
-    static INLINE CONST vect_t blend_twice(const vect_t a, const vect_t b) {
-        return _mm256_blend_epi16(a, b, s);
+    template<uint16_t s,
+             typename std::enable_if<(s & 0x00ff) == (s >> 8)>::type* = nullptr>
+    static INLINE vect_t blend (const vect_t a, const vect_t b) {
+        /* If the 8-bit low part of s is equal to the 8-bit high part of s, we
+         * can use the _mm256_blend_epi16 intrinsic directly.
+         */
+        return _mm256_blend_epi16(a, b, s & 0x00ff);
+    }
+    template<uint16_t s,
+             typename std::enable_if<(s & 0x00ff) != (s >> 8)>::type* = nullptr>
+    static INLINE vect_t blend (const vect_t a, const vect_t b) {
+        /* If the 8-bit low part of s is different from the 8-bit high part of
+         * s, we need to do the blend on each 128-bit lane separately and
+         * combine them to obtain the result.
+         */
+        vect_t lo = _mm256_blend_epi16(a, b, s & 0xff);
+        vect_t hi = _mm256_blend_epi16(a, b, s >> 8);
+        return _mm256_permute2x128_si256 (lo, hi, 0x30);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int32.inl
@@ -346,10 +346,11 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd256i_base {
     }
 
     /*
-     * Blend packed 32-bit integers from a and b using control mask imm8, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[s[0]?a0:b0,   , s[7]?a7:b7] int32_t
+     * Blend 32-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       s = a 8-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[7] ? a7 : b7 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_int64.inl
@@ -340,11 +340,21 @@ template <> struct Simd256_impl<true, true, true, 8> : public Simd256i_base {
      [b0, b1, b2, b3] int64_t
      * Return : [s[0]?a0:b0,   , s[3]?a3:b3] int64_t
      */
+    /*
+     * Blend 64-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a3 ]
+     *       b = [ b0, ..., b3 ]
+     *       s = a 4-bit immediate integer
+     * Return: [ s[0] ? a0 : b0, ..., s[3] ? a3 : b3 ]
+     */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {
-        // _mm_blend_epi16 is faster than _mm_blend_epi32 and require SSE4.1 instead of AVX2
-        // We have to transform s = [d3 d2 d1 d0]_base2 to s1 = [d3 d3 d2 d2 d1 d1 d0 d0]_base2
-        constexpr uint8_t s1 = (s & 0x1) * 3 + (((s & 0x2) << 1)*3)  + (((s & 0x4) << 2)*3) + (((s & 0x8) << 3)*3);
+        /* We need to use _mm256_blend_epi32.
+         * We need to transform s = [d3 d2 d1 d0]_base2
+         * into s1 = [d3 d3 d2 d2 d1 d1 d0 d0]_base2
+         */
+        constexpr uint8_t s1 = (s & 0x1) * 3 + (((s & 0x2) << 1)*3)
+                                + (((s & 0x4) << 2)*3) + (((s & 0x8) << 3)*3);
         return _mm256_blend_epi32(a, b, s1);
     }
 

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -296,32 +296,20 @@ template <> struct Simd512_impl<true, false, true, 8> {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using mask,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] double
-     [b0, b1, b2, b3, b4, b5, b6, b7] double
-     * Return : [mask[31]?a0:b0, ..., mask[511]?a7:b7] double
-
-     A TESTER
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using the vector mask as control.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       mask
+     * Return: [ mask[31] ? a0 : b0, ..., mask[511] ? a7 : b7 ]
      */
-
     static INLINE CONST vect_t blendv(const vect_t a, const vect_t b, const vect_t mask) {
-        __m256d lowa  = _mm512_castpd512_pd256(a);
-        __m256d higha = _mm512_extractf64x4_pd(a,1);
-
-        __m256d lowb  = _mm512_castpd512_pd256(b);
-        __m256d highb = _mm512_extractf64x4_pd(b,1);
-
-        __m256d lowmask  = _mm512_castpd512_pd256(mask);
-        __m256d highmask = _mm512_extractf64x4_pd(mask,1);
-
-        __m256d reslow = _mm256_blendv_pd(lowa, lowb, lowmask);
-        __m256d reshigh = _mm256_blendv_pd(higha, highb, highmask);
-
-        __m512d res = _mm512_castpd256_pd512(reslow);
-        res = _mm512_insertf64x4(res, reshigh, 1);
-
-        return res;
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
+        __mmask8 k = _mm512_movepi64_mask (_mm512_castpd_si512 (mask));
+#else
+        __mmask8 k = _mm512_cmplt_epi64_mask (_mm512_castpd_si512 (mask), _mm512_setzero_si512());
+#endif
+        return _mm512_mask_blend_pd (k, a, b);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -283,13 +283,12 @@ template <> struct Simd512_impl<true, false, true, 8> {
     }
 
     /*
-     * Blend packed double-precision (64-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] double
-     [b0, b1, b2, b3, b4, b5, b6, b7] double
-     * Return : [s[0]?a0:b0, ..., s[7]?a7:b7] double
-
-     A TESTER
+     * Blend packed double-precision (64-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       s = a 8-bit mask
+     * Return: [ s[0] ? a0 : b0, ..., s[7] ? a7 : b7 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_double.inl
@@ -543,7 +543,7 @@ template <> struct Simd512_impl<true, false, true, 8> {
      * Return : [round(a0), round(a1), round(a2), round(a3), round(a4), round(a5), round(a6), round(a7)]
      */
     static INLINE CONST vect_t round(const vect_t a) {
-        return _mm512_roundscale_pd(a, 0);
+        return _mm512_roundscale_pd(a, _MM_FROUND_TO_NEAREST_INT);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -605,7 +605,7 @@ template <> struct Simd512_impl<true, false, true, 4> {
      *			round(a8), round(a9), round(a10), round(a11), round(a12), round(a13), round(a14), round(a15)]
      */
     static INLINE CONST vect_t round(const vect_t a) {
-        return _mm512_roundscale_ps(a, 0);
+        return _mm512_roundscale_ps(a, _MM_FROUND_TO_NEAREST_INT);
     }
 
     /*

--- a/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_float.inl
@@ -279,14 +279,12 @@ template <> struct Simd512_impl<true, false, true, 4> {
     }
 
     /*
-     * Blend packed single-precision (32-bit) floating-point elements from a and b using control mask s,
-     * and store the results in dst.
-     * uint8_t became uint16_t
-     * Args   :	[a0, ..., a15] float
-     *			[b0, ..., b15] float
-     * Return :	[s[0]?a0:b0, ..., s[15]?a15:b15] float
-
-     A TESTER
+     * Blend packed single-precision (32-bit) floating-point elements from a and
+     * b using control mask s.
+     * Args: a = [ a0, ..., a15 ]
+     *       b = [ b0, ..., b15 ]
+     *       s = a 16-bit mask
+     * Return: [ s[0] ? a0 : b0, ..., s[15] ? a15 : b15 ]
      */
     template<uint16_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int32.inl
@@ -356,17 +356,18 @@ template <> struct Simd256_impl<true, true, true, 4> : public Simd512i_base {
         odd = _mm512_permutexvar_epi32 (s, hi)
     }
 
-    /*TODO BLEND
-     * Blend packed 32-bit integers from a and b using control mask imm8, and store the results in dst.
-     * Args   :	[a0, ..., a7] int32_t
-     [b0, ..., b7] int32_t
-     * Return :	[s[0]?a0:b0,   , s[7]?a7:b7] int32_t
+    /*
+     * Blend 32-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a15 ]
+     *       b = [ b0, ..., b15 ]
+     *       s = a 16-bit mask
+     * Return: [ s[0] ? a0 : b0, ..., s[15] ? a15 : b15 ]
      */
-    /*template<uint8_t s>
-      static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {
-      return _mm256_blend_epi32(a, b, s);
-      }
-      */
+    template<uint16_t s>
+    static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {
+      return _mm512_mask_blend_epi32(s, a, b);
+    }
+
     /*
      * Add packed 32-bits integer in a and b, and store the results in vect_t.
      * Args   : [a0, ..., a15] 						int32_t

--- a/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd512_int64.inl
@@ -340,17 +340,14 @@ template <> struct Simd512_impl<true, true, true, 8> : public Simd512i_base {
     }
 
     /*
-     * Blend packed 64-bit integers from a and b using control mask imm8, and store the results in dst.
-     * Args   : [a0, a1, a2, a3, a4, a5, a6, a7] int64_t
-     [b0, b1, b2, b3, b4, b5, b6, b7] int64_t
-     * Return : [s[0]?a0:b0,   , s[7]?a7:b7] int64_t
+     * Blend 64-bit integers from a and b using control mask s.
+     * Args: a = [ a0, ..., a7 ]
+     *       b = [ b0, ..., b7 ]
+     *       s = a 8-bit mask
+     * Return: [ s[0] ? a0 : b0, ..., s[7] ? a7 : b7 ]
      */
     template<uint8_t s>
     static INLINE CONST vect_t blend(const vect_t a, const vect_t b) {
-        // _mm_blend_epi16 is faster than _mm_blend_epi32 and require SSE4.1 instead of AVX2
-        // We have to transform s = [d3 d2 d1 d0]_base2 to s1 = [d3 d3 d2 d2 d1 d1 d0 d0]_base2
-        //constexpr uint8_t s1 = (s & 0x1) * 3 + (((s & 0x2) << 1)*3)  + (((s & 0x4) << 2)*3) + (((s & 0x8) << 3)*3);
-        //std::cerr<<"blend simd512_int64"<<std::endl;
         return _mm512_mask_blend_epi64(s, a, b);
     }
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -459,7 +459,20 @@ struct ScalFunctionsBase<Element,
         return std::floor(x);
     }
     static Element round (Element x) {
-        return std::round(x);
+        /* SSE and AVX round to nearest even integer value. The round function
+         * from standard C++ library round to nearest with rounding up for half
+         * integer. So we need to do a bit more work on the case of half integer
+         * to completely emulate the behaviour of SSE and AVX.
+         */
+        Element r = std::round(x);
+        if (std::abs (x - r) == 0.5)
+        {
+            if (std::fmod (r, 2.) == 1.)
+                r -= 1.;
+            else if (std::fmod (r, 2.) == -1.)
+                r += 1.;
+        }
+        return r;
     }
     static Element blendv (Element a, Element b, Element mask) {
         using IntType = typename make_unsigned_int<Element>::type;

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -268,24 +268,6 @@ public:
     using enable_if_t = typename enable_if<B, T>::type;
 
     /*** Constructor **********************************************************/
-    /* Constructor to test method such that
-     *  - Arguments of the Simd method are vect_t or any type built from vect_t
-     *      with const and references. If any, the arguments with references
-     *      must appear first.
-     *  - The return value of the Simd method is vect_t or void. [cf the
-     *      templated method evaluate_simd_method]
-     *  - For the scalar method, the supported types are
-     * Element (Element...)
-     * vectElt (vectElt...)
-     * void (vectElt...)
-     *  - Arguments of the scalar method are all of type Element (or resp.
-     *      vectElt) or any type built from Element (or resp. vectElt) with
-     *      const and references. If any, the arguments with references must
-     *      appear first.
-     *  - The return value of the scalar method is Element (if all arguments are
-     *  Elements) or vectElt or void (if all arguments are vectElt). [cf the
-     *      templated method evaluate_scalar_method]
-     */
     template <typename...AScal, typename RScal,
               typename...ASimd, typename RSimd,
               enable_if_t<sizeof...(AScal) == sizeof...(ASimd)>* = nullptr,

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -461,6 +461,15 @@ struct ScalFunctionsBase<Element,
     static Element round (Element x) {
         return std::round(x);
     }
+    static Element blendv (Element a, Element b, Element mask) {
+        using IntType = typename make_unsigned_int<Element>::type;
+        IntType *ptr = (IntType *) &mask;
+        *ptr = *ptr >> (8*sizeof(Element)-1);
+        if (*ptr & 0x1)
+            return b;
+        else
+            return a;
+    }
 
     static Element fma (Element x, Element y, Element z) {
         return std::fma(x,y,z);
@@ -753,6 +762,7 @@ test_impl_base () {
     TEST_ONE_OP (floor);
     TEST_ONE_OP (mulin);
     TEST_ONE_OP (div);
+    TEST_ONE_OP (blendv);
 
     return btest;
 }

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -25,7 +25,7 @@
  */
 
 #include "givaro/givinteger.h" /* for Givaro::Integer */
-#include "givaro/givprint.h" /* for operator<< with vector */
+#include "givaro/modular.h"
 #include "fflas-ffpack/fflas-ffpack-config.h"
 #include "fflas-ffpack/fflas/fflas_simd.h"
 #include "fflas-ffpack/utils/args-parser.h" /* for parsing command-line args */
@@ -41,7 +41,8 @@
 #include <type_traits>
 #include <algorithm>
 
-typedef Givaro::Integer integer;
+using Givaro::Integer;
+using Givaro::Modular;
 using std::cout;
 using std::endl;
 using std::string;
@@ -53,23 +54,7 @@ using std::enable_if;
 using std::is_floating_point;
 using std::is_integral;
 using std::is_signed;
-using std::equal;
 using std::remove_reference;
-
-/* For pretty printing type */
-template<typename...> const char *TypeName();
-
-#define REGISTER_TYPE_NAME(type) \
-    template<> const char *TypeName<type>(){return #type;}
-
-REGISTER_TYPE_NAME(float);
-REGISTER_TYPE_NAME(double);
-REGISTER_TYPE_NAME(int16_t);
-REGISTER_TYPE_NAME(int32_t);
-REGISTER_TYPE_NAME(int64_t);
-REGISTER_TYPE_NAME(uint16_t);
-REGISTER_TYPE_NAME(uint32_t);
-REGISTER_TYPE_NAME(uint64_t);
 
 /******************************************************************************/
 /* Random generators **********************************************************/
@@ -77,7 +62,7 @@ REGISTER_TYPE_NAME(uint64_t);
 
 static std::mt19937 entropy_generator;
 
-template <class Element, class Alloc>
+template <typename Element, typename Alloc>
 typename enable_if<is_integral<Element>::value>::type
 generate_random_vector (vector<Element,Alloc> &a) {
     typedef typename std::uniform_int_distribution<Element> RandGen;
@@ -85,7 +70,7 @@ generate_random_vector (vector<Element,Alloc> &a) {
     std::generate (a.begin(), a.end(), [&](){return G(entropy_generator);});
 }
 
-template <class Element, class Alloc>
+template <typename Element, typename Alloc>
 typename enable_if<is_floating_point<Element>::value>::type
 generate_random_vector (vector<Element,Alloc> &a) {
     typedef typename std::uniform_real_distribution<Element> RandGen;
@@ -94,11 +79,61 @@ generate_random_vector (vector<Element,Alloc> &a) {
 }
 
 /******************************************************************************/
-/* Utils functions ************************************************************/
+/* Utils structs for enable_if ************************************************/
 /******************************************************************************/
+/* Testing if all bool, given as template, are true */
+template <bool...v>
+struct ALL;
 
+template <bool...v>
+struct ALL<true, v...> { static constexpr bool value = ALL<v...>::value; } ;
+
+template <bool...v>
+struct ALL<false, v...> { static constexpr bool value = false; };
+
+template <>
+struct ALL<> { static constexpr bool value = true; };
+
+/* Counting the number of lvalue reference in parameter pack */
+template <typename...T>
+struct count_lvalue_reference;
+
+template <typename T, typename...O>
+struct count_lvalue_reference<T, O...> {
+    static constexpr size_t n = count_lvalue_reference<O...>::n;
+};
+
+template <typename T, typename...O>
+struct count_lvalue_reference<T&, O...> {
+    static constexpr size_t n = std::integral_constant<size_t, 1>::value
+                                            + count_lvalue_reference<O...>::n;
+};
+
+template <>
+struct count_lvalue_reference<> {
+    static constexpr size_t n = std::integral_constant<size_t, 0>::value;
+};
+
+/*
+ * Check that all types given in the parameter pack Args are the same as T, once
+ * the constness and the references are removed.
+ */
+template <typename...Args>
+struct is_all_same;
+
+template <typename T, typename...Args>
+struct is_all_same<T, Args...> { static constexpr bool value = ALL<std::is_same< typename std::remove_cv<typename remove_reference<T>::type>::type, typename std::remove_cv<typename remove_reference<Args>::type>::type>::value...>::value; };
+
+template <>
+struct is_all_same<> { static constexpr bool value = true; };
+
+
+
+/******************************************************************************/
+/* Utils functions and structs ************************************************/
+/******************************************************************************/
 /* check equality for integral type */
-template <class Element>
+template <typename Element>
 typename enable_if<is_integral<Element>::value, bool>::type
 check_eq (Element x, Element y)
 {
@@ -106,195 +141,345 @@ check_eq (Element x, Element y)
 }
 
 /* check equality for floating point type */
-template <class Element>
+template <typename Element>
 typename enable_if<is_floating_point<Element>::value, bool>::type
 check_eq (Element x, Element y)
 {
     return (std::isnan(x) && std::isnan(y)) || x == y;
 }
 
+/* Check if two vectors are equal (using check_eq) */
+template <typename Element>
+bool
+cmp (vector<Element> out_scal, vector<Element> out_simd)
+{
+    auto eq = check_eq<Element>;
+    return std::equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
+}
+
 /* evaluate the function f with arguments taken in the array */
-template <class Ret, class T>
+template <typename Ret, typename T>
 Ret
-eval_func_on_array (function<Ret()> f, array<T, 0> arr)
+eval_func_on_array (function<Ret()> f, array<T, 0>& arr)
 {
     return f();
 }
 
-template <class Ret, class T, class...TArgs>
+template <typename T, typename...TArgs>
+void
+eval_func_on_array (function<void(T, TArgs...)> f,
+                    array<typename remove_reference<T>::type, sizeof...(TArgs)+1> &arr)
+{
+    function<void(TArgs...)> newf = [&] (TArgs...args) -> void { return f(arr[0], args...);};
+    array<typename remove_reference<T>::type, sizeof...(TArgs)> newarr;
+    std::copy (std::next(arr.begin()), arr.end(), newarr.begin());
+    eval_func_on_array (newf, newarr);
+    std::copy (newarr.begin(), newarr.end(), std::next(arr.begin()));
+}
+
+template <typename Ret, typename T, typename...TArgs>
 Ret
 eval_func_on_array (function<Ret(T, TArgs...)> f,
                     array<typename remove_reference<T>::type, sizeof...(TArgs)+1> &arr)
 {
     function<Ret(TArgs...)> newf = [&] (TArgs...args) -> Ret { return f(arr[0], args...);};
     array<typename remove_reference<T>::type, sizeof...(TArgs)> newarr;
-    for (size_t i = 0; i < sizeof...(TArgs); i++)
-        newarr[i] = arr[i+1];
-    return eval_func_on_array (newf, newarr);
+    std::copy (std::next(arr.begin()), arr.end(), newarr.begin());
+    Ret r = eval_func_on_array (newf, newarr);
+    std::copy (newarr.begin(), newarr.end(), std::next(arr.begin()));
+    return r;
 }
 
+/******************************************************************************/
+/* Utils for pretty printing vectors ******************************************/
+/******************************************************************************/
+template <typename T>
+struct width { static constexpr size_t value = 2+2*sizeof(T); };
+
+template <>
+struct width<float> { static constexpr size_t value = 15; };
+template <>
+struct width<double> { static constexpr size_t value = 23; };
+
+/* pretty printing vectors */
+template <typename E>
+std::ostream& operator<< (std::ostream& o, const vector<E>& V)
+{
+    const std::ios::fmtflags old_settings = o.flags();
+    const char prev = o.fill();
+    if (is_floating_point<E>::value)
+        o << std::hexfloat << std::right;
+    else if (is_integral<E>::value)
+        o << std::hex << std::showbase << std::internal << std::setfill ('0');
+    for (size_t i = 0; i < V.size(); i++)
+    {
+        o << (i ? ", " : "[ ");
+        if (is_integral<E>::value && V[i] == 0)
+            o << "0x" << std::setw(width<E>::value-2) << V[i];
+        else
+            o << std::setw(width<E>::value) << V[i];
+    }
+    o << " ]";
+    o.fill(prev);
+    o.flags(old_settings);
+    return o;
+}
 
 /******************************************************************************/
 /* Main test function *********************************************************/
 /******************************************************************************/
-
-template <class Simd, class RScal, class...AScal, class RSimd, class...ASimd>
-typename enable_if<sizeof...(AScal) == sizeof...(ASimd), bool>::type
-test_op (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname) {
-
-    using Element = typename Simd::scalar_t;
-    using ScalVectAlign = AlignedAllocator<Element, Alignment(Simd::alignment)>;
-    using ScalVect = vector<Element, ScalVectAlign>;
-    using SimdVect = typename Simd::vect_t;
-    constexpr size_t SimdVectSize = Simd::vect_size;
-    constexpr size_t arity = sizeof...(AScal);
-
-    /* input vectors */
-    vector<ScalVect> inputs (arity, ScalVect(SimdVectSize));
-    for (auto &iv: inputs)
-        generate_random_vector (iv);
-
-    /* output vectors */
-    ScalVect out_scal(SimdVectSize), out_simd(SimdVectSize);
-
-    /* compute with scalar function */
-    array<Element, arity> scal_in;
-    function<RScal(AScal...)> fscal = FScal;
-    for(size_t i = 0 ; i < SimdVectSize ; i++) {
-        for (size_t j = 0; j < arity; j++)
-            scal_in[j] = inputs[j][i];
-
-        out_scal[i] = eval_func_on_array (fscal, scal_in);
-    }
-
-    /* compute with SIMD function */
-    array<SimdVect, arity> simd_in;
-    function<RSimd(ASimd...)> fsimd = FSimd;
-    for (size_t i = 0; i < arity; i++)
-        simd_in[i] = Simd::load (inputs[i].data());
-
-    SimdVect simd_out = eval_func_on_array (fsimd, simd_in);
-    Simd::store (out_simd.data(), simd_out);
-
-    /* comparison */
-    auto eq = check_eq<Element>;
-    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
-
-    /* print result line */
-    cout << Simd::type_string() << "::" << fname << " "
-         << string (69 - fname.size() - Simd::type_string().size(), '.')
-         << " " << (res ? "success" : "failure") << endl;
-
-    /* in case of error, print all input and output values */
-    if(!res) {
-        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
-        for (size_t i = 0; i < arity; i++) {
-            cout << "input_" << i << ": " << inputs[i] << endl;
-        }
-        cout << "out_scal: " << out_scal << endl;
-        cout << "out_simd: " << out_simd << endl;
-        cout << string (80, '-') << endl;
-    }
-    return res;
-}
-
-template <class Simd, class RScal, class...AScal, class RSimd, class...ASimd>
-typename enable_if<sizeof...(AScal) == sizeof...(ASimd), bool>::type
-test_vop_ri2 (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...), string fname)
+class TestBaseDefault
 {
-    using Element = typename Simd::scalar_t;
-    using ScalVect = vector<Element>;
-    using SimdVect = typename Simd::vect_t;
-    constexpr size_t SimdVectSize = Simd::vect_size;
-    constexpr size_t arity = sizeof...(AScal);
-
-    /* input vectors */
-    vector<ScalVect> inputs (arity, ScalVect(SimdVectSize));
-    for (auto &iv: inputs)
-        generate_random_vector (iv);
-
-    /* output vectors */
-    ScalVect out_scal(SimdVectSize), out_simd(SimdVectSize);
-
-    /* compute with scalar function */
-    function<RScal(AScal...)> fscal = FScal;
-    out_scal = fscal (inputs[0], inputs[1]);
-
-    /* compute with SIMD function */
-    array<SimdVect, arity> simd_in;
-    function<RSimd(ASimd...)> fsimd = FSimd;
-    for (size_t i = 0; i < arity; i++)
-        simd_in[i] = Simd::loadu (inputs[i].data());
-
-    SimdVect simd_out = eval_func_on_array (fsimd, simd_in);
-    Simd::storeu (out_simd.data(), simd_out);
-
-    /* comparison */
-    auto eq = check_eq<Element>;
-    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
-
-    /* print result line */
-    cout << Simd::type_string() << "<" << TypeName<Element>() << ">::" << fname
-         << " " << string (60 - fname.size() - strlen(TypeName<Element>()), '.')
-         << " " << (res ? "success" : "failure") << endl;
-
-    /* in case of error, print all input and output values */
-    if(!res) {
-        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
-        for (size_t i = 0; i < arity; i++) {
-            cout << "input_" << i << ": " << inputs[i] << endl;
-        }
-        cout << "out_scal: " << out_scal << endl;
-        cout << "out_simd: " << out_simd << endl;
-        cout << string (80, '-') << endl;
+public:
+    template <typename T>
+    static void genInputs (vector<vector<T>> &inputs) {
+        for (auto &iv: inputs)
+            generate_random_vector (iv);
     }
-    return res;
-}
+
+};
+
+/* Class to perform the test a given method from a Simd struct against a method
+ * in the ScalFunctions struct. It can handle the following cases:
+ *  - Arguments of the Simd method are vect_t or any type built from vect_t
+ *      with const and references. If any, the arguments with references
+ *      must appear first.
+ *  - The return value of the Simd method is vect_t or void. [cf the
+ *      templated method evaluate_simd_method]
+ *  - Arguments of the scalar method are all of type Element (or resp.
+ *      vectElt) or any type built from Element (or resp. vectElt) with
+ *      const and references. If any, the arguments with references must
+ *      appear first.
+ *  - The return value of the scalar method is Element (if all arguments are
+ *  Elements) or vectElt or void (if all arguments are vectElt). [cf the
+ *      templated method evaluate_scalar_method]
+ */
+template <typename Simd, typename Base = TestBaseDefault>
+class TestOneMethod : public Base
+{
+public:
+    using Element = typename Simd::scalar_t;
+    using vect_t = typename Simd::vect_t;
+    using vectElt = vector<Element>;
+    constexpr static size_t vect_size = Simd::vect_size;
+    using Base::genInputs;
+
+    template <bool B, typename T = void>
+    using enable_if_t = typename enable_if<B, T>::type;
+
+    /*** Constructor **********************************************************/
+    /* Constructor to test method such that
+     *  - Arguments of the Simd method are vect_t or any type built from vect_t
+     *      with const and references. If any, the arguments with references
+     *      must appear first.
+     *  - The return value of the Simd method is vect_t or void. [cf the
+     *      templated method evaluate_simd_method]
+     *  - For the scalar method, the supported types are
+     * Element (Element...)
+     * vectElt (vectElt...)
+     * void (vectElt...)
+     *  - Arguments of the scalar method are all of type Element (or resp.
+     *      vectElt) or any type built from Element (or resp. vectElt) with
+     *      const and references. If any, the arguments with references must
+     *      appear first.
+     *  - The return value of the scalar method is Element (if all arguments are
+     *  Elements) or vectElt or void (if all arguments are vectElt). [cf the
+     *      templated method evaluate_scalar_method]
+     */
+    template <typename...AScal, typename RScal,
+              typename...ASimd, typename RSimd,
+              enable_if_t<sizeof...(AScal) == sizeof...(ASimd)>* = nullptr,
+              enable_if_t<count_lvalue_reference<AScal...>::n == count_lvalue_reference<ASimd...>::n>* = nullptr,
+              enable_if_t<is_all_same<AScal...>::value>* = nullptr,
+              enable_if_t<is_all_same<vect_t, ASimd...>::value>* = nullptr>
+    TestOneMethod (RSimd (&FSimd) (ASimd...), RScal (&FScal) (AScal...),
+                                                string fname) : name(fname) {
+        /* Constants are computed with AScal, but could have been with ASimd */
+        constexpr size_t arity = sizeof...(AScal);
+        nb_lref = count_lvalue_reference<AScal...>::n;
+        constexpr bool is_return_void = std::is_same<RScal, void>::value;
+
+        inputs.resize (arity, vectElt(vect_size));
+        outputs_simd.resize (nb_lref+(is_return_void?0:1), vectElt(vect_size));
+        outputs_scalar.resize(nb_lref+(is_return_void?0:1), vectElt(vect_size));
+
+        genInputs (inputs);
+
+        /* compute with scalar function */
+        function<RScal(AScal...)> fscal(FScal);
+        evaluate_scalar_method (fscal);
+
+        /* compute with SIMD function */
+        array<vect_t, arity> simd_in;
+        function<RSimd(ASimd...)> fsimd(FSimd);
+        /* convert input into vect_t */
+        for (size_t i = 0; i < inputs.size(); i++)
+            simd_in[i] = Simd::loadu (inputs[i].data());
+        /* evaluate simd function */
+        evaluate_simd_method (fsimd, simd_in);
+        /* get back arguments passed as lvalue reference */
+        for (size_t j = 0; j < nb_lref; j++)
+            Simd::storeu (outputs_simd[j].data(), simd_in[j]);
+    }
+
+    /*** To evaluation scalar method ******************************************/
+    /* Element (Element...) */
+    template <typename...AScal>
+    enable_if_t<is_all_same<Element, AScal...>::value, void>
+    evaluate_scalar_method (function<Element(AScal...)> fscal) {
+        array<Element, sizeof...(AScal)> scal_in;
+        for(size_t i = 0 ; i < Simd::vect_size; i++) {
+            for (size_t j = 0; j < inputs.size(); j++)
+                scal_in[j] = inputs[j][i];
+            /* evaluate scalar function */
+            outputs_scalar[nb_lref][i] = eval_func_on_array (fscal, scal_in);
+            /* get back arguments passed as lvalue reference */
+            for (size_t j = 0; j < nb_lref; j++)
+                outputs_scalar[j][i] = scal_in[j];
+        }
+    }
+
+    /* vectElt (vectElt...) */
+    template <typename...AScal>
+    enable_if_t<is_all_same<vectElt, AScal...>::value, void>
+    evaluate_scalar_method (function<vectElt(AScal...)> fscal) {
+        array<vectElt, sizeof...(AScal)> scal_in;
+        std::copy (inputs.begin(), inputs.end(), scal_in.begin());
+        /* evaluate scalar function */
+        outputs_scalar[nb_lref] = eval_func_on_array (fscal, scal_in);
+        /* get back arguments passed as lvalue reference */
+        for (size_t j = 0; j < nb_lref; j++)
+            outputs_scalar[j] = scal_in[j];
+    }
+
+    /* void (vectElt...) */
+    template <typename...AScal>
+    enable_if_t<is_all_same<vectElt, AScal...>::value, void>
+    evaluate_scalar_method (function<void(AScal...)> fscal) {
+        array<vectElt, sizeof...(AScal)> scal_in;
+        std::copy (inputs.begin(), inputs.end(), scal_in.begin());
+        /* evaluate scalar function */
+        eval_func_on_array (fscal, scal_in);
+        /* get back arguments passed as lvalue reference */
+        for (size_t j = 0; j < nb_lref; j++)
+            outputs_scalar[j] = scal_in[j];
+    }
+
+    /*** To evaluation Simd method ********************************************/
+    /* vect_t (vect_t...) */
+    template <typename...ASimd>
+    enable_if_t<is_all_same<vect_t, ASimd...>::value, void>
+    evaluate_simd_method (function<vect_t(ASimd...)> fsimd,
+                                    array<vect_t, sizeof...(ASimd)>& simd_in) {
+        vect_t simd_out = eval_func_on_array (fsimd, simd_in);
+        /* store the results */
+        Simd::storeu (outputs_simd[nb_lref].data(), simd_out);
+    }
+
+    /* void (vect_t...) */
+    template <typename...ASimd>
+    enable_if_t<is_all_same<vect_t, ASimd...>::value, void>
+    evaluate_simd_method (function<void(ASimd...)> fsimd,
+                                    array<vect_t, sizeof...(ASimd)>& simd_in) {
+        eval_func_on_array (fsimd, simd_in);
+    }
+
+    /*** Utils ****************************************************************/
+    bool getStatus () const {
+        bool status = true;
+        for (size_t i = 0; i < outputs_scalar.size(); i++)
+            status &= cmp (outputs_scalar[i], outputs_simd[i]);
+        return status;
+    }
+
+    string getTestName () const {
+        return name;
+    }
+
+    bool writeResultLine () const {
+        bool status = getStatus();
+        cout << Simd::type_string() << "::" << getTestName() << " "
+             << string (69-getTestName().size()-Simd::type_string().size(), '.')
+             << " " << (status ? "success" : "failure") << endl;
+        return status;
+    }
+
+    void writeDebugData () const {
+        const std::ios::fmtflags old_settings = cout.flags();
+
+        auto eq = check_eq<Element>;
+        const size_t w = width<Element>::value;
+        const size_t w2 = 16;
+        const size_t fw = vect_size*(w+2)+2+w2;
+        const string h("debug data");
+
+        cout << string ((fw-h.size()-2)/2, '#') << " " << h << " "
+             << string ((fw-h.size()-1)/2, '#') << endl;
+
+        cout << "# Input" << endl;
+        for (size_t i = 0; i < inputs.size(); i++) {
+            cout << "         arg" << i << " = " << inputs[i] << endl;
+        }
+
+        cout << "# Output" << endl;
+        for (size_t i = 0; i < outputs_scalar.size(); i++) {
+            if (i < nb_lref)
+                cout << "  scalar_arg" << i << " = " << outputs_scalar[i]
+                     << endl
+                     << "    simd_arg" << i << " = " << outputs_simd[i] << endl;
+            else
+                cout << "scalar_output = " << outputs_scalar[i] << endl
+                     << "  simd_output = " << outputs_simd[i] << endl;
+            cout << string (w2, ' ');
+            for (unsigned j = 0; j < vect_size; j++) {
+                bool b = eq (outputs_scalar[i][j], outputs_simd[i][j]);
+                cout << (j ? ", " : "[ ") << string (w, b ? '=' : 'X');
+            }
+            cout << " ]" << endl;
+        }
+        cout << string (fw, '#') << endl << endl;
+
+        cout.flags(old_settings);
+    }
+
+protected:
+    size_t nb_lref;
+    string name;
+    vector<vectElt> inputs;
+    vector<vectElt> outputs_simd;
+    vector<vectElt> outputs_scalar;
+};
+
+class TestBaseWithZero
+{
+public:
+    template <typename T>
+    static void genInputs (vector<vector<T>> &inputs) {
+        TestBaseDefault::genInputs (inputs);
+        for (auto &v: inputs[0])
+            v = 0;
+    }
+};
 
 /******************************************************************************/
 /* Scalar functions for comparisons *******************************************/
 /******************************************************************************/
 
-template <class Element, class Enable = void>
-struct ScalFunctions;
+template <typename Element, typename Enable = void>
+struct ScalFunctionsBase;
 
 /* for floating point element */
-template <class Element>
-struct ScalFunctions<Element,
+template <typename Element>
+struct ScalFunctionsBase<Element,
                     typename enable_if<is_floating_point<Element>::value>::type>
 {
-    using VectElement = vector<Element>;
-    static Element zero () {
-        return 0.0;
-    }
-    static Element vand (Element x1, Element x2) {
-        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
-        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
-        for (unsigned int i = 0; i < sizeof (Element); i++)
-            p1[i] &= p2[i];
-        return x1;
-    }
-    static Element vor (Element x1, Element x2) {
-        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
-        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
-        for (unsigned int i = 0; i < sizeof (Element); i++)
-            p1[i] |= p2[i];
-        return x1;
-    }
-    static Element vxor (Element x1, Element x2) {
-        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
-        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
-        for (unsigned int i = 0; i < sizeof (Element); i++)
-            p1[i] ^= p2[i];
-        return x1;
-    }
-    static Element vandnot (Element x1, Element x2) {
-        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
-        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
-        for (unsigned int i = 0; i < sizeof (Element); i++)
-            p1[i] = (~p1[i]) & p2[i];
-        return x1;
-    }
+    static constexpr Element _zero = 0.0;
+    /* For cmp, when true, we return a NaN and assumes the value returned by the
+     * Simd methods (0xFFFF...FFFF) is also a NaN.
+     */
+    static constexpr Element cmp_true = NAN;
+    static constexpr Element cmp_false = _zero;
+
     static Element ceil (Element x) {
         return std::ceil(x);
     }
@@ -304,135 +489,39 @@ struct ScalFunctions<Element,
     static Element round (Element x) {
         return std::round(x);
     }
-    static Element add (Element x1, Element x2) {
-        return x1+x2;
-    }
-    static Element addin (Element &x1, Element x2) {
-        return x1+=x2;
-    }
-    static Element sub (Element x1, Element x2) {
-        return x1-x2;
-    }
-    static Element subin (Element &x1, Element x2) {
-        return x1-=x2;
-    }
-    static Element mul (Element x1, Element x2) {
-        return x1*x2;
-    }
-    static Element mulin (Element &x1, Element x2) {
-        return x1*=x2;
-    }
-    static Element div (Element x1, Element x2) {
-        return x1/x2;
-    }
-    static Element fmadd (Element x1, Element x2, Element x3) {
-        return std::fma(x3,x2,x1);
-    }
-    static Element fmaddin (Element &x1, Element x2, Element x3) {
-        return x1 = std::fma(x3,x2,x1);
-    }
-    static Element fmsub (Element x1, Element x2, Element x3) {
-        return std::fma(x3,x2,-x1);
-    }
-    static Element fmsubin (Element &x1, Element x2, Element x3) {
-        return x1 = std::fma(x3,x2,-x1);
-    }
-    static Element fnmadd (Element x1, Element x2, Element x3) {
-        return std::fma(-x3,x2,x1);
-    }
-    static Element fnmaddin (Element &x1, Element x2, Element x3) {
-        return x1 = std::fma(-x3,x2,x1);
-    }
-    /* Comparisons functions in SIMD output 0 or 0xFFFF...FFFF
-     * (here we assume 0xFFFF...FFFF is always a NAN)
-     */
-    static Element lesser (Element x1, Element x2) {
-        return (x1<x2)?NAN:0;
-    }
-    static Element lesser_eq (Element x1, Element x2) {
-        return (x1<=x2)?NAN:0;
-    }
-    static Element greater (Element x1, Element x2) {
-        return (x1>x2)?NAN:0;
-    }
-    static Element greater_eq (Element x1, Element x2) {
-        return (x1>=x2)?NAN:0;
-    }
-    static Element eq (Element x1, Element x2) {
-        return (x1==x2)?NAN:0;
-    }
-    static VectElement unpacklo (VectElement a, VectElement b) {
-        VectElement r(a.size());
-        for (size_t i = 0; i < a.size(); i++)
-            r[i] = (i % 2 ? b[i/2] : a[i/2]);
-        return r;
-    }
-    static VectElement unpackhi (VectElement a, VectElement b) {
-        VectElement r(a.size());
-        for (size_t i = 0; i < a.size(); i++)
-            r[i] = (i % 2 ? b[(a.size()+i)/2] : a[(a.size()+i)/2]);
-        return r;
-    }
-    static VectElement pack_even (VectElement a, VectElement b) {
-        VectElement r(a.size());
-        for (size_t i = 0; i < a.size(); i++)
-            r[i] = (i < a.size()/2 ? a[2*i] : b[2*i-a.size()]);
-        return r;
-    }
-    static VectElement pack_odd (VectElement a, VectElement b) {
-        VectElement r(a.size());
-        for (size_t i = 0; i < a.size(); i++)
-            r[i] = (i < a.size()/2 ? a[1+2*i] : b[1+2*i-a.size()]);
-        return r;
+
+    static Element fma (Element x, Element y, Element z) {
+        return std::fma(x,y,z);
     }
 };
 
 /* for integral element */
-template <class Element>
-struct ScalFunctions<Element,
+template <typename Element>
+struct ScalFunctionsBase<Element,
                     typename enable_if<is_integral<Element>::value>::type>
 {
-    using VectElement = vector<Element>;
-    static Element zero () {
-        return 0;
-    }
+    static constexpr Element _zero = 0;
+    /* For cmp, when true, we return -1 and assumes it is equal to the value
+     * returned by the Simd methods (0xFFFF...FFFF).
+     */
+    static constexpr Element cmp_true = -1;
+    static constexpr Element cmp_false = _zero;
+
     static Element round (Element x) {
         return x;
     }
-    static Element vand (Element x1, Element x2) {
-        return x1 & x2;
+
+    static Element fma (Element x, Element y, Element z) {
+        return x*y + z;
     }
-    static Element vor (Element x1, Element x2) {
-        return x1 | x2;
-    }
-    static Element vxor (Element x1, Element x2) {
-        return x1 ^ x2;
-    }
-    static Element vandnot (Element x1, Element x2) {
-        return (~x1) & x2;
-    }
-    static Element add (Element x1, Element x2) {
-        return x1+x2;
-    }
-    static Element addin (Element &x1, Element x2) {
-        return x1+=x2;
-    }
-    static Element sub (Element x1, Element x2) {
-        return x1-x2;
-    }
-    static Element subin (Element &x1, Element x2) {
-        return x1-=x2;
-    }
-    static Element mul (Element x1, Element x2) {
-        return x1*x2;
-    }
+
     static Element mullo (Element x1, Element x2) {
         return x1*x2;
     }
     static Element mulhi (Element x1, Element x2) {
-        integer q,r;
-        integer a = (integer(x1)*integer(x2));
-        integer b = integer(1) << uint64_t(sizeof(Element)*8);
+        Integer q,r;
+        Integer a = (Integer(x1)*Integer(x2));
+        Integer b = Integer(1) << uint64_t(sizeof(Element)*8);
         Givaro::IntegerDom Z;
         Z.divmod(q, r, a, b);
         return Element(q);
@@ -454,35 +543,17 @@ struct ScalFunctions<Element,
         }
         return x1*x2;
     }
-    static Element fmadd (Element x1, Element x2, Element x3) {
-        return x1 + x2*x3;
-    }
-    static Element fmaddin (Element &x1, Element x2, Element x3) {
-        return x1 += x2*x3;
-    }
     static Element fmaddx (Element x1, Element x2, Element x3) {
         return x1 + mulx (x2, x3);
     }
     static Element fmaddxin (Element &x1, Element x2, Element x3) {
         return x1 += mulx (x2, x3);
     }
-    static Element fmsub (Element x1, Element x2, Element x3) {
-        return -x1 + x2*x3;
-    }
-    static Element fmsubin (Element &x1, Element x2, Element x3) {
-        return x1 = -x1 + x2*x3;
-    }
     static Element fmsubx (Element x1, Element x2, Element x3) {
         return -x1 + mulx (x2, x3);
     }
     static Element fmsubxin (Element &x1, Element x2, Element x3) {
         return x1 = -x1 + mulx (x2, x3);
-    }
-    static Element fnmadd (Element x1, Element x2, Element x3) {
-        return x1 - x2*x3;
-    }
-    static Element fnmaddin (Element &x1, Element x2, Element x3) {
-        return x1 -= x2*x3;
     }
     static Element fnmaddx (Element x1, Element x2, Element x3) {
         return x1 - mulx(x2, x3);
@@ -519,288 +590,240 @@ struct ScalFunctions<Element,
     static Element sll (Element x1) {
         return ((typename std::make_unsigned<Element>::type) x1) << s;
     }
+};
 
-    /* Comparisons functions in SIMD output 0 or 0xFFFF...FFFF */
+template <typename Element>
+struct ScalFunctions : public ScalFunctionsBase<Element>
+{
+    using vectElt = vector<Element>;
+    using ScalFunctionsBase<Element>::cmp_true;
+    using ScalFunctionsBase<Element>::cmp_false;
+    using ScalFunctionsBase<Element>::fma;
+
+    static Element zero () {
+        return ScalFunctionsBase<Element>::_zero;
+    }
+    static Element vand (Element x1, Element x2) {
+        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
+        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
+        for (unsigned int i = 0; i < sizeof (Element); i++)
+            p1[i] &= p2[i];
+        return x1;
+    }
+    static Element vor (Element x1, Element x2) {
+        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
+        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
+        for (unsigned int i = 0; i < sizeof (Element); i++)
+            p1[i] |= p2[i];
+        return x1;
+    }
+    static Element vxor (Element x1, Element x2) {
+        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
+        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
+        for (unsigned int i = 0; i < sizeof (Element); i++)
+            p1[i] ^= p2[i];
+        return x1;
+    }
+    static Element vandnot (Element x1, Element x2) {
+        unsigned char *p1 = reinterpret_cast<unsigned char *>(&x1);
+        unsigned char *p2 = reinterpret_cast<unsigned char *>(&x2);
+        for (unsigned int i = 0; i < sizeof (Element); i++)
+            p1[i] = (~p1[i]) & p2[i];
+        return x1;
+    }
+    static Element add (Element x1, Element x2) {
+        return x1+x2;
+    }
+    static Element addin (Element &x1, Element x2) {
+        return x1+=x2;
+    }
+    static Element sub (Element x1, Element x2) {
+        return x1-x2;
+    }
+    static Element subin (Element &x1, Element x2) {
+        return x1-=x2;
+    }
+    static Element mul (Element x1, Element x2) {
+        return x1*x2;
+    }
+    static Element mulin (Element &x1, Element x2) {
+        return x1*=x2;
+    }
+    static Element div (Element x1, Element x2) {
+        return x1/x2;
+    }
+    static Element fmadd (Element x1, Element x2, Element x3) {
+        return fma(x3,x2,x1);
+    }
+    static Element fmaddin (Element &x1, Element x2, Element x3) {
+        return x1 = fma(x3,x2,x1);
+    }
+    static Element fmsub (Element x1, Element x2, Element x3) {
+        return fma(x3,x2,-x1);
+    }
+    static Element fmsubin (Element &x1, Element x2, Element x3) {
+        return x1 = fma(x3,x2,-x1);
+    }
+    static Element fnmadd (Element x1, Element x2, Element x3) {
+        return fma(-x3,x2,x1);
+    }
+    static Element fnmaddin (Element &x1, Element x2, Element x3) {
+        return x1 = fma(-x3,x2,x1);
+    }
+
     static Element lesser (Element x1, Element x2) {
-        return (x1<x2)?-1:0;
+        return (x1<x2)? cmp_true : cmp_false;
     }
     static Element lesser_eq (Element x1, Element x2) {
-        return (x1<=x2)?-1:0;
+        return (x1<=x2)? cmp_true : cmp_false;
     }
     static Element greater (Element x1, Element x2) {
-        return (x1>x2)?-1:0;
+        return (x1>x2)? cmp_true : cmp_false;
     }
     static Element greater_eq (Element x1, Element x2) {
-        return (x1>=x2)?-1:0;
+        return (x1>=x2)? cmp_true : cmp_false;
     }
     static Element eq (Element x1, Element x2) {
-        return (x1==x2)?-1:0;
+        return (x1==x2)? cmp_true : cmp_false;
     }
-    static VectElement unpacklo (VectElement a, VectElement b) {
-        VectElement r(a.size());
+
+    static vectElt unpacklo (vectElt a, vectElt b) {
+        vectElt r(a.size());
         for (size_t i = 0; i < a.size(); i++)
             r[i] = (i % 2 ? b[i/2] : a[i/2]);
         return r;
     }
-    static VectElement unpackhi (VectElement a, VectElement b) {
-        VectElement r(a.size());
+
+    static vectElt unpackhi (vectElt a, vectElt b) {
+        vectElt r(a.size());
         for (size_t i = 0; i < a.size(); i++)
             r[i] = (i % 2 ? b[(a.size()+i)/2] : a[(a.size()+i)/2]);
         return r;
     }
-    static VectElement pack_even (VectElement a, VectElement b) {
-        VectElement r(a.size());
+    static void unpacklohi (vectElt &lo, vectElt &hi, vectElt a, vectElt b) {
+        lo = unpacklo (a, b);
+        hi = unpackhi (a, b);
+    }
+    static vectElt pack_even (vectElt a, vectElt b) {
+        vectElt r(a.size());
         for (size_t i = 0; i < a.size(); i++)
             r[i] = (i < a.size()/2 ? a[2*i] : b[2*i-a.size()]);
         return r;
     }
-    static VectElement pack_odd (VectElement a, VectElement b) {
-        VectElement r(a.size());
+    static vectElt pack_odd (vectElt a, vectElt b) {
+        vectElt r(a.size());
         for (size_t i = 0; i < a.size(); i++)
             r[i] = (i < a.size()/2 ? a[1+2*i] : b[1+2*i-a.size()]);
         return r;
     }
+    static void pack (vectElt &even, vectElt &odd, vectElt a, vectElt b) {
+        even = pack_even (a, b);
+        odd = pack_odd (a, b);
+    }
 };
-
-/******************************************************************************/
-/* Tests that does not fit in the generic framework of test_op ****************/
-/******************************************************************************/
-template <class Simd, class Scal>
-bool
-do_test_greater_with_zero ()
-{
-    using Element = typename Simd::scalar_t;
-    using SimdVect = typename Simd::vect_t;
-    constexpr size_t SimdVectSize = Simd::vect_size;
-
-    vector<Element> v(SimdVectSize), out_scal(SimdVectSize),
-                                     out_simd(SimdVectSize);
-    generate_random_vector (v);
-
-    /* compute with scalar function */
-    for(size_t i = 0 ; i < SimdVectSize ; i++)
-        out_scal[i] = Scal::greater (0, v[i]);
-
-    /* compute with SIMD function */
-    SimdVect r = Simd::greater (Simd::set1 (0), Simd::loadu (v.data()));
-    Simd::storeu (out_simd.data(), r);
-
-    /* comparison */
-    auto eq = check_eq<Element>;
-    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
-
-    /* print result line */
-    cout << Simd::type_string() << "<" << TypeName<Element>()
-         << "> test greater_with_zero"
-         << " " << string (39 - strlen(TypeName<Element>()), '.')
-         << " " << (res ? "success" : "failure") << endl;
-
-    /* in case of error, print all input and output values */
-    if(!res) {
-        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
-        cout << "v: " << v << endl;
-        cout << "out_scal: " << out_scal << endl;
-        cout << "out_simd: " << out_simd << endl;
-        cout << string (80, '-') << endl;
-    }
-    return res;
-}
-
-template <class Simd, class Scal>
-bool
-do_test_lesser_with_zero ()
-{
-    using Element = typename Simd::scalar_t;
-    using SimdVect = typename Simd::vect_t;
-    constexpr size_t SimdVectSize = Simd::vect_size;
-
-    vector<Element> v(SimdVectSize), out_scal(SimdVectSize),
-                                     out_simd(SimdVectSize);
-    generate_random_vector (v);
-
-    /* compute with scalar function */
-    for(size_t i = 0 ; i < SimdVectSize ; i++)
-        out_scal[i] = Scal::lesser (0, v[i]);
-
-    /* compute with SIMD function */
-    SimdVect r = Simd::lesser (Simd::set1 (0), Simd::loadu (v.data()));
-    Simd::storeu (out_simd.data(), r);
-
-    /* comparison */
-    auto eq = check_eq<Element>;
-    bool res = equal (out_scal.begin(), out_scal.end(), out_simd.begin(), eq);
-
-    /* print result line */
-    cout << Simd::type_string() << "<" << TypeName<Element>()
-         << "> test lesser_with_zero"
-         << " " << string (40 - strlen(TypeName<Element>()), '.')
-         << " " << (res ? "success" : "failure") << endl;
-
-    /* in case of error, print all input and output values */
-    if(!res) {
-        cout << string (10, '-') << " debug data " << string (58, '-') << endl;
-        cout << "v: " << v << endl;
-        cout << "out_scal: " << out_scal << endl;
-        cout << "out_simd: " << out_simd << endl;
-        cout << string (80, '-') << endl;
-    }
-    return res;
-}
 
 /******************************************************************************/
 /* Test one SIMD implem *******************************************************/
 /******************************************************************************/
 
-#define TEST_ONE_OP(name) \
-    btest &= test_op<simd> (simd::name, Scal::name, #name);
-#define TEST_ONE_VOP_RI2(name) \
-    btest &= test_vop_ri2<simd> (simd::name, Scal::name, #name);
+#define COMMA ,
+
+#define _TEST_ONE(K, f1, f2, n) do {    \
+        K T(f1, f2, n);                 \
+        bool b = T.writeResultLine();            \
+        if (b == false)     \
+            T.writeDebugData();         \
+        btest &= b;         \
+    } while (0)
+
+#define TEST_ONE_OP(f) _TEST_ONE(TestOneMethod<Simd>, Simd::f, Scal::f, #f)
+#define TEST_ONE_OP_WZ(f) _TEST_ONE(TestOneMethod<Simd COMMA TestBaseWithZero>,\
+                                        Simd::f, Scal::f, #f " test with zero")
 
 /* for floating point element */
-template<class simd, class Element>
+template<typename Simd, typename Element>
 typename enable_if<is_floating_point<Element>::value, bool>::type
-test_impl () {
+test_impl_base () {
     using Scal = ScalFunctions<Element>;
     bool btest = true;
 
-    TEST_ONE_OP (zero);
-    TEST_ONE_OP (vand);
-    TEST_ONE_OP (vor);
-    TEST_ONE_OP (vxor);
-    TEST_ONE_OP (vandnot);
     TEST_ONE_OP (ceil);
     TEST_ONE_OP (floor);
-    TEST_ONE_OP (round);
-    TEST_ONE_OP (add);
-    TEST_ONE_OP (addin);
-    TEST_ONE_OP (sub);
-    TEST_ONE_OP (subin);
-    TEST_ONE_OP (mul);
     TEST_ONE_OP (mulin);
     TEST_ONE_OP (div);
-    TEST_ONE_OP (fmadd);
-    TEST_ONE_OP (fmaddin);
-    TEST_ONE_OP (fmsub);
-    TEST_ONE_OP (fmsubin);
-    TEST_ONE_OP (fnmadd);
-    TEST_ONE_OP (fnmaddin);
-    TEST_ONE_OP (lesser);
-    btest &= do_test_lesser_with_zero<simd, Scal> ();
-    TEST_ONE_OP (lesser_eq);
-    TEST_ONE_OP (greater);
-    btest &= do_test_greater_with_zero<simd, Scal> ();
-    TEST_ONE_OP (greater_eq);
-    TEST_ONE_OP (eq);
-    TEST_ONE_VOP_RI2 (unpacklo);
-    TEST_ONE_VOP_RI2 (unpackhi);
-    TEST_ONE_VOP_RI2 (pack_even);
-    TEST_ONE_VOP_RI2 (pack_odd);
 
     return btest;
 }
 
 /* for integral element */
-template<class simd, class Element>
+template<typename Simd, typename Element>
 typename enable_if<is_integral<Element>::value, bool>::type
-test_impl () {
+test_impl_base () {
     using Scal = ScalFunctions<Element>;
     bool btest = true;
 
-    TEST_ONE_OP (zero);
-    TEST_ONE_OP (round);
-    TEST_ONE_OP (vand);
-    TEST_ONE_OP (vor);
-    TEST_ONE_OP (vxor);
-    TEST_ONE_OP (vandnot);
-    TEST_ONE_OP (add);
-    TEST_ONE_OP (addin);
-    TEST_ONE_OP (sub);
-    TEST_ONE_OP (subin);
-    TEST_ONE_OP (mul);
     TEST_ONE_OP (mullo);
     TEST_ONE_OP (mulhi);
     TEST_ONE_OP (mulx);
-    TEST_ONE_OP (fmadd);
-    TEST_ONE_OP (fmaddin);
     TEST_ONE_OP (fmaddx);
     TEST_ONE_OP (fmaddxin);
-    TEST_ONE_OP (fmsub);
-    TEST_ONE_OP (fmsubin);
     TEST_ONE_OP (fmsubx);
     TEST_ONE_OP (fmsubxin);
-    TEST_ONE_OP (fnmadd);
-    TEST_ONE_OP (fnmaddin);
     TEST_ONE_OP (fnmaddx);
     TEST_ONE_OP (fnmaddxin);
-    TEST_ONE_OP (lesser);
-    btest &= do_test_lesser_with_zero<simd, Scal> ();
-    TEST_ONE_OP (lesser_eq);
-    TEST_ONE_OP (greater);
-    btest &= do_test_greater_with_zero<simd, Scal> ();
-    TEST_ONE_OP (greater_eq);
-    TEST_ONE_OP (eq);
     TEST_ONE_OP (template sra<3>);
     TEST_ONE_OP (template sra<7>);
     TEST_ONE_OP (template srl<5>);
     TEST_ONE_OP (template srl<11>);
     TEST_ONE_OP (template sll<2>);
     TEST_ONE_OP (template sll<13>);
-    TEST_ONE_VOP_RI2 (unpacklo);
-    TEST_ONE_VOP_RI2 (unpackhi);
-    TEST_ONE_VOP_RI2 (pack_even);
-    TEST_ONE_VOP_RI2 (pack_odd);
 
     return btest;
 }
 
-/******************************************************************************/
-/* Test all SIMD implems for one Element type *********************************/
-/******************************************************************************/
-template<class Element>
-typename enable_if<is_integral<Element>::value, bool>::type
-test () {
-    bool test = true;
+template<typename Simd, typename Element>
+bool
+test_impl () {
+    using Scal = ScalFunctions<Element>;
+    bool btest = test_impl_base<Simd, Element>();
 
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
-    test &= test_impl<Simd128<Element>, Element>();
-    cout << endl;
-#endif
+    TEST_ONE_OP (zero);
+    TEST_ONE_OP (vand);
+    TEST_ONE_OP (vor);
+    TEST_ONE_OP (vxor);
+    TEST_ONE_OP (vandnot);
+    TEST_ONE_OP (round);
+    TEST_ONE_OP (add);
+    TEST_ONE_OP (addin);
+    TEST_ONE_OP (sub);
+    TEST_ONE_OP (subin);
+    TEST_ONE_OP (mul);
+    TEST_ONE_OP (fmadd);
+    TEST_ONE_OP (fmaddin);
+    TEST_ONE_OP (fmsub);
+    TEST_ONE_OP (fmsubin);
+    TEST_ONE_OP (fnmadd);
+    TEST_ONE_OP (fnmaddin);
+    TEST_ONE_OP (lesser);
+    TEST_ONE_OP (lesser_eq);
+    TEST_ONE_OP (greater);
+    TEST_ONE_OP (greater_eq);
+    TEST_ONE_OP (eq);
+    TEST_ONE_OP_WZ (lesser);
+    TEST_ONE_OP_WZ (lesser_eq);
+    TEST_ONE_OP_WZ (greater);
+    TEST_ONE_OP_WZ (greater_eq);
+    TEST_ONE_OP_WZ (eq);
+    TEST_ONE_OP (unpacklo);
+    TEST_ONE_OP (unpackhi);
+    TEST_ONE_OP (unpacklohi);
+    TEST_ONE_OP (pack_even);
+    TEST_ONE_OP (pack_odd);
+    TEST_ONE_OP (pack);
 
-#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
-    test &= test_impl<Simd256<Element>, Element>();
-    cout << endl;
-#endif
-
-#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
-    test &= test_impl<Simd512<Element>, Element>();
-    cout << endl;
-#endif
-
-    return test;
+    return btest;
 }
 
-template<class Element>
-typename enable_if<is_floating_point<Element>::value, bool>::type
-test () {
-    bool test = true;
-
-#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
-    test &= test_impl<Simd128<Element>, Element>();
-    cout << endl;
-#endif
-
-#ifdef __FFLASFFPACK_HAVE_AVX_INSTRUCTIONS
-    test &= test_impl<Simd256<Element>, Element>();
-    cout << endl;
-#endif
-
-#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
-    test &= test_impl<Simd512<Element>, Element>();
-    cout << endl;
-#endif
-
-    return test;
-}
 
 /******************************************************************************/
 /* Main ***********************************************************************/
@@ -822,23 +845,54 @@ main (int argc, char *argv[]) {
     entropy_generator.seed (seed);
 
     bool pass  = true ;
-    pass &= test<float>();
-    pass &= test<double>();
-#ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
-        // Not yet implemented over AVX512
-    pass &= test<int16_t>();
-    pass &= test<int32_t>();
-#endif
+
+#define TEST_IMPL(SIZE, Elt) do {       \
+        pass &= test_impl<Simd##SIZE<Elt>, Elt>(); \
+        cout << endl; \
+    } while (0)
+
+#ifdef __FFLASFFPACK_HAVE_SSE4_1_INSTRUCTIONS
+    TEST_IMPL(128, float);
+    TEST_IMPL(128, double);
+    TEST_IMPL(128, int16_t);
+    TEST_IMPL(128, uint16_t);
+    TEST_IMPL(128, int32_t);
+    TEST_IMPL(128, uint32_t);
 #ifdef __x86_64__
-    pass &= test<int64_t>();
+    TEST_IMPL(128, int64_t);
+    TEST_IMPL(128, uint64_t);
 #endif
-#ifndef __FFLASFFPACK_HAVE_AVX512F_INSTRUCTIONS
-        // Not yet implemented over AVX512
-    pass &= test<uint16_t>();
-    pass &= test<uint32_t>();
 #endif
+
+#ifdef __FFLASFFPACK_HAVE_AVX_INSTRUCTIONS
+    TEST_IMPL(256, float);
+    TEST_IMPL(256, double);
+#endif
+
+#ifdef __FFLASFFPACK_HAVE_AVX2_INSTRUCTIONS
+    TEST_IMPL(256, int16_t);
+    TEST_IMPL(256, uint16_t);
+    TEST_IMPL(256, int32_t);
+    TEST_IMPL(256, uint32_t);
 #ifdef __x86_64__
-    pass &= test<uint64_t>();
+    TEST_IMPL(256, int64_t);
+    TEST_IMPL(256, uint64_t);
+#endif
+#endif
+
+#ifdef __FFLASFFPACK_HAVE_AVX512DQ_INSTRUCTIONS
+    TEST_IMPL(512, float);
+    TEST_IMPL(512, double);
+    /* Simd512<(u)int16> does not exist. */
+    /* Simd512<(u)int32> exists but was commented out in the previous version of
+     * this test. Why ?
+     */
+    //TEST_IMPL(512, int32_t);
+    //TEST_IMPL(512, uint32_t);
+#ifdef __x86_64__
+    TEST_IMPL(512, int64_t);
+    TEST_IMPL(512, uint64_t);
+#endif
 #endif
     cout << endl << "Test " << (pass ? "passed" : "failed") << endl;
     return pass ? 0 : 1;

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -731,8 +731,6 @@ struct ScalFunctions : public ScalFunctionsBase<Element>
 /* Test one SIMD implem *******************************************************/
 /******************************************************************************/
 
-#define COMMA ,
-
 #define _TEST_ONE(K, f1, f2, r, n) do {     \
         K T(f1, f2, r, n);                  \
         bool b = T.writeResultLine();       \

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -422,10 +422,29 @@ struct ScalFunctionsBase<Element,
     static constexpr Element cmp_true = NAN;
     static constexpr Element cmp_false = _zero;
 
-    static uniform_real_distribution<Element> get_default_random_generator () {
-        Element m = std::numeric_limits<Element>::lowest();
-        Element M = std::numeric_limits<Element>::max();
-        return uniform_real_distribution<Element>(m, M);
+    class FloatingPointTestDistribution
+    {
+        public:
+            using IntType = typename make_unsigned_int<Element>::type;
+
+            FloatingPointTestDistribution () : intdist(std::numeric_limits<IntType>::lowest(), std::numeric_limits<IntType>::max()) {
+            }
+
+            template< class Generator >
+            Element operator()( Generator& g )
+            {
+                IntType tmp = intdist (g);
+                Element *fp_ptr = reinterpret_cast<Element *>(&tmp);
+                return *fp_ptr;
+            }
+
+        private:
+            uniform_int_distribution<IntType> intdist;
+
+    };
+
+    static FloatingPointTestDistribution get_default_random_generator () {
+        return FloatingPointTestDistribution();
     }
 
     static Element ceil (Element x) {

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -178,9 +178,9 @@ template <typename T>
 struct width { static constexpr size_t value = 2+2*sizeof(T); };
 
 template <>
-struct width<float> { static constexpr size_t value = 15; };
+struct width<float> { static constexpr size_t value = 16; };
 template <>
-struct width<double> { static constexpr size_t value = 23; };
+struct width<double> { static constexpr size_t value = 24; };
 
 /* pretty printing vectors */
 template <typename E>

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -702,6 +702,13 @@ struct ScalFunctions : public ScalFunctionsBase<Element>
         even = pack_even (a, b);
         odd = pack_odd (a, b);
     }
+    template <uint16_t s>
+    static vectElt blend (vectElt a, vectElt b) {
+        vectElt r(a.size());
+        for (size_t i = 0; i < a.size(); i++)
+            r[i] = ((s >> i) & 0x1) ? b[i] : a[i];
+        return r;
+    }
 };
 
 /******************************************************************************/
@@ -768,6 +775,7 @@ bool
 test_impl () {
     using Scal = ScalFunctions<Element>;
     bool btest = test_impl_base<Simd, Element>();
+    constexpr uint16_t blendmask = (0x1ul << Simd::vect_size) - 1;
 
     TEST_ONE_OP (zero);
     TEST_ONE_OP (vand);
@@ -802,6 +810,10 @@ test_impl () {
     TEST_ONE_OP (pack_even);
     TEST_ONE_OP (pack_odd);
     TEST_ONE_OP (pack);
+    TEST_ONE_OP (template blend<0x5555 & blendmask>);
+    TEST_ONE_OP (template blend<0x9999 & blendmask>);
+    TEST_ONE_OP (template blend<0xd7d7 & blendmask>);
+    TEST_ONE_OP (template blend<0xdead & blendmask>);
 
     return btest;
 }


### PR DESCRIPTION
The goal of this PR is to improve the framework used in `test-simd.C` (in order to be able to use it to test the methods from `simd-modular.inl` that I am currently trying to rewrite).
The rewriting of `test-simd` allows to test more methods from Simd structs (like unpacklohi and pack). It also now tests that the arguments passed as reference are correct once the method is called (it allows me to detect typos in the declaration of `fmsubxin` in `simd128-int64.inl`, that I fixed in commit 8f3ecdad67037b7ef44b97ac8008c00d278df39e in this PR)

Bonus question: in the previous `test-simd.C` file, the tests for `Simd512<(u)int32_t>` were commented out, does anyone know why ? There is no test for `Simd512<(u)int16_t>` because the file `simd512-int16.inl` does not exist, but for `Simd512<(u)int32_t>`, the file do exist. Without answer to this question, I will leave the tests commented as before.