### PR TITLE
Update autotools scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,15 +90,6 @@ ARCH_FLAGS
 # Append -mfpmath=sse to OPTIM_FLAGS on i386 and i686 architecture with SSE
 FPMATH_FLAGS
 
-# With GCC 4.x, the default ABI version is 2. With this version, __m128 and
-# __m256 are the same types and therefore we cannot have overloads for both
-# types without linking error. It is fixed in ABI version 4.
-# FIXME: Why do we set ABI version to 6
-AS_CASE([$CCNAM], [gcc4*], [REQUIRED_FLAGS+=" -fabi-version=6"])
-
-dnl gcc-4.9.2 bug See https://trac.sagemath.org/ticket/17635#comment:178
-AS_CASE([$CCNAM], [gcc492], [REQUIRED_FLAGS+=" -fpermissive"])
-
 AS_ECHO([---------------------------------------])
 # Machine characteristics
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,9 @@ AS_ECHO([---------------------------------------])
 # Set OPTIM_FLAGS, DEBUG_FLAGS depending on compiler and command line arguments
 SET_FLAGS
 
-# Append -march=native to OPTIM_FLAGS if not present in CXXFLAGS and
-# not cross-compiling and --no-marchnative is not set
+# Append -march=native or -mcpu=native (if recognized by the compiler) to
+# OPTIM_FLAGS if not present in CXXFLAGS and not cross-compiling and
+# --without-archnative is not set
 ARCH_FLAGS
 
 # Append -mfpmath=sse to OPTIM_FLAGS on i386 and i686 architecture with SSE

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -131,28 +131,6 @@ AC_DEFUN([AC_COMPILER_NAME], [
             [ CCNAM=gcc ])
         ])
 
-    dnl 4.3 <= GCC < 5 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ == 4 && __GNUC_MINOR__ >= 3) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gcc4 ])
-        ])
-
-    dnl GCC == 4.9.2 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ == 4  && __GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ == 2 ) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gcc492 ])
-        ])
-
 		dnl  other ?
 
 		AS_IF([ test -z "${CCNAM}"],


### PR DESCRIPTION
This PR removes support for gcc4 (same as linbox-team/givaro#170) and use `-mcpu` when `-march` flag is not supported ((same as linbox-team/givaro#168)


Fix #313