### PR TITLE
Fix linking with internal libraries.

### DIFF
--- a/fflas-ffpack/interfaces/libs/Makefile.am
+++ b/fflas-ffpack/interfaces/libs/Makefile.am
@@ -24,7 +24,6 @@ pkgincludesubdir=$(pkgincludedir)/interfaces/libs
 
 AM_CXXFLAGS = $(FFLASFFPACK_CXXFLAGS) $(GIVARO_CFLAGS) $(BLAS_CFLAGS) $(PARFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)
-LDADD = $(GIVARO_LIBS) $(BLAS_LIBS) $(PARLIBS)
 #AM_LDFLAGS=-static 
 
 
@@ -55,32 +54,26 @@ libfflas_la_SOURCES= fflas_L1_inst.C \
 		    fflas_L3_inst.C \
 		    fflas_L3_inst_implem.inl
 
-libfflas_la_LDFLAGS=  $(LDADD) -version-info 1:0:0 \
-	             -no-undefined
+libfflas_la_LIBADD= $(GIVARO_LIBS) $(BLAS_LIBS) $(PARLIBS)
+libfflas_la_LDFLAGS= -version-info 1:0:0 -no-undefined
 
 libffpack_la_SOURCES= ffpack_inst.C \
 		      ffpack_inst_implem.inl
-libffpack_la_LDFLAGS= $(LDADD) -version-info 1:0:0 \
-		       -no-undefined $(top_builddir)/fflas-ffpack/interfaces/libs/libfflas.la
-
-EXTRA_libffpack_la_DEPENDENCIES= libfflas.la
+libffpack_la_LIBADD= libfflas.la
+libffpack_la_LDFLAGS= -version-info 1:0:0 -no-undefined
 
 libfflas_c_la_SOURCES=fflas_lvl1.C \
 		    fflas_lvl2.C \
 		    fflas_lvl3.C \
 		    fflas_sparse.C
 #libfflas_c_la_CPPFLAGS=$(AM_CPPFLAGS) -DFFLAS_COMPILED -DFFPACK_COMPILED
-libfflas_c_la_LDFLAGS=  $(LDADD) -version-info 1:0:0 \
-                       -no-undefined 	$(top_builddir)/fflas-ffpack/interfaces/libs/libfflas.la
-
-EXTRA_libfflas_c_la_DEPENDENCIES=libfflas.la
+libfflas_c_la_LIBADD= libfflas.la
+libfflas_c_la_LDFLAGS= -version-info 1:0:0 -no-undefined
 
 libffpack_c_la_SOURCES=ffpack.C
 #libffpack_c_la_CPPFLAGS=$(AM_CPPFLAGS) -DFFLAS_COMPILED -DFFPACK_COMPILED
-libffpack_c_la_LDFLAGS=  $(LDADD) -version-info 1:0:0 \
-		        -no-undefined -lfflas -lffpack
-EXTRA_libffpack_c_la_DEPENDENCIES=libffpack.la
-
+libffpack_c_la_LIBADD= libffpack.la
+libffpack_c_la_LDFLAGS= -version-info 1:0:0 -no-undefined
 
 EXTRA_DIST=c_libs.doxy
 


### PR DESCRIPTION
When building fflas-ffpack with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CXX --mode=link g++ -O2 -march=native -Wall -DNDEBUG -UDEBUG -I/tmp/delme/usr/local/include -L/tmp/delme/usr/local/lib -lgivaro -lgmpxx -lgmp -lcblas -lblas -version-info 1:0:0 -no-undefined -lfflas -lffpack -o libffpack_c.la -rpath /usr/local/lib ffpack.lo

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/fflas-ffpack/fflas-ffpack/interfaces/libs"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 3171}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 3168}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(3,"../",O_DIRECTORY,0) = 4.
rdlibtool: lconf: fstat(4,...) = 0 {.st_dev = 45, .st_ino = 2962}.
rdlibtool: lconf: openat(4,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(4,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 2819}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/fflas-ffpack/libtool".
rdlibtool: link: x86_64-pc-linux-gnu-ar crs .libs/libffpack_c.a .libs/ffpack.o
rdlibtool: link: g++ .libs/ffpack.o -O2 -march=native -Wall -DNDEBUG -UDEBUG -I/tmp/delme/usr/local/include -L/tmp/delme/usr/local/lib -lgivaro -lgmpxx -lgmp -lcblas -lblas -lfflas -lffpack -shared -fPIC -Wl,--no-undefined -Wl,-soname -Wl,libffpack_c.so.1 -o .libs/libffpack_c.so.1.0.0
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lfflas
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lffpack
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1598: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 2055.
make[3]: *** [Makefile:578: libffpack_c.la] Error 2
make[3]: Leaving directory '/tmp/fflas-ffpack/fflas-ffpack/interfaces/libs'
make[2]: *** [Makefile:415: install-recursive] Error 1
make[2]: Leaving directory '/tmp/fflas-ffpack/fflas-ffpack/interfaces'
make[1]: *** [Makefile:476: install-recursive] Error 1
make[1]: Leaving directory '/tmp/fflas-ffpack/fflas-ffpack'
make: *** [Makefile:567: install-recursive] Error 1
```
This reveals several issues.
    
* Internal libraries should never link with linker flags and should use the libtool archive (.la) files instead.
* These should be added to LIBADD for libraries or LDADD for programs and never to LDFLAGS which is only for other linker flags.
* The _DEPENDENCIES do not need to be set manually since the defaults will be correct if the LIBADD/LDADD variables are set correctly.
* This issue is masked if fflas-ffpack is already installed where `-lfflas` and `-lffpack` are found installed on the system and not in the build directory.
* There is overlinking of dependencies where the same dependencies are linked repeatedly.
    
Making these changes allows both slibtool and GNU libtool to build correctly, the latter is far more permissive and silently hides this issue.

See this downstream issue: https://bugs.gentoo.org/787746

Also as a side note, GNU libtool has a long standing issue where is silently ignores `-no-undefined` while slibtool does not have this issue. This is not a problem here, but it is something to keep in mind. :)