### PR TITLE
Fix test-simd for machine without FMA

### DIFF
--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -485,7 +485,11 @@ struct ScalFunctionsBase<Element,
     }
 
     static Element fma (Element x, Element y, Element z) {
+#ifdef __FMA__
         return std::fma(x,y,z);
+#else
+        return (x*y) + z;
+#endif
     }
 };
 


### PR DESCRIPTION
FMA is not used in SIMD on those machine so we should not use std::fma to compute the no simd output to compare to.