### PR TITLE
Fix the implementation of Simd for machine with AVX but without FMA

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
+++ b/fflas-ffpack/fflas/fflas_simd/simd256_double.inl
@@ -75,6 +75,11 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
     template <class Field>
     using is_same_element = std::is_same<typename Field::Element, scalar_t>;
 
+    union Converter {
+        vect_t v;
+        scalar_t t[vect_size];
+    };
+
     /*
      * Check if the pointer p is a multiple of alignemnt
      */
@@ -388,7 +393,14 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
 #ifdef __FMA__
         return _mm256_fmadd_pd(a, b, c);
 #else
-        return add(c, mul(a, b));
+	Converter ca, cb, cc;
+        ca.v = a;
+        cb.v = b;
+        cc.v = c;
+        return set(std::fma (ca.t[0], cb.t[0], cc.t[0]),
+                   std::fma (ca.t[1], cb.t[1], cc.t[1]),
+                   std::fma (ca.t[2], cb.t[2], cc.t[2]),
+                   std::fma (ca.t[3], cb.t[3], cc.t[3]) );
 #endif
     }
 
@@ -404,7 +416,7 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
 #ifdef __FMA__
         return _mm256_fnmadd_pd(a, b, c);
 #else
-        return sub(c, mul(a, b));
+	return fmadd (c, sub (zero(), a), b);
 #endif
     }
 
@@ -420,7 +432,7 @@ template <> struct Simd256_impl<true, false, true, 8> : public Simd256fp_base {
 #ifdef __FMA__
         return _mm256_fmsub_pd(a, b, c);
 #else
-        return sub(mul(a, b), c);
+	return fmadd (sub (zero(), c), a, b);
 #endif
     }
 

--- a/tests/test-simd.C
+++ b/tests/test-simd.C
@@ -485,11 +485,7 @@ struct ScalFunctionsBase<Element,
     }
 
     static Element fma (Element x, Element y, Element z) {
-#ifdef __FMA__
         return std::fma(x,y,z);
-#else
-        return (x*y) + z;
-#endif
     }
 };
 


### PR DESCRIPTION
For machine with AVX but without FMA, write a better fallback implementation of fmadd (and co). 

Revert the fix from PR #347 (as it is not needed anymore, the simd always compute a correct fma now)

Fix test-simd in Linbox