### PR TITLE
Fix Simd on i686: SimdChooser, #ifdef guard

### DIFF
--- a/fflas-ffpack/fflas/fflas_simd.h
+++ b/fflas-ffpack/fflas/fflas_simd.h
@@ -384,6 +384,20 @@ struct SimdChooser<T, true, true> // integral number
 #endif
 };
 
+#ifndef __x86_64__
+template <>
+struct SimdChooser<uint64_t, true, true>
+{
+    using value = NoSimd<uint64_t>;
+};
+
+template <>
+struct SimdChooser<int64_t, true, true>
+{
+    using value = NoSimd<int64_t>;
+};
+#endif
+
 template <class T> using Simd = typename SimdChooser<T>::value;
 
 // template <class T> struct SimdChooser<T, true> {


### PR DESCRIPTION
The goal of this PR is to fix #356.
Can someone with a i686 CPU with SSE4 or AVX2 can check that commit 9b6083c663096e9ca85775b79f1f27c848dbeb98 indeed fix the problem.