### PR TITLE
fix license in readme (remains ambiguity GPL/LGPL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is inspired by the BLAS interface (Basic Linear Algebra Subprograms) and the 
 
 ## LICENSE
 
-FFLAS-FFPACK is distributed unded the terms of the GNU LGPL v2.1 or later (see LICENSE).
+FFLAS-FFPACK is distributed under the terms of the GNU LGPL v2.1 or later (see COPYING and COPYING.LESSER).
 
 ## REQUIREMENTS:
 - a C++ compiler supporting C++11 standard. More precisely g++ v5 or greater, clang++ v3.4 or greater, icpc v16 or greater (earlier versions of clang and icpc might also work but have not been tested)


### PR DESCRIPTION
The README file mentioned the licensing in a supposed "LICENSE" file. It seems it would rather be the "COPYING" or the "COPYING.LESSER" file. The latter concerns the LGPL, which is the announced licensing.

Before merging: is it necessary to keep both files, including "COPYING" which is about the GPL? If not, I would suggest to remove it (and modify the README line accordingly).