### PR TITLE
don't convert when Field==Modular<double>

### DIFF
--- a/fflas-ffpack/fflas/fflas_fgemm.inl
+++ b/fflas-ffpack/fflas/fflas_fgemm.inl
@@ -410,7 +410,9 @@ namespace FFLAS {
             else if (!std::is_same<Field,Givaro::ModularBalanced<float> >::value){
                 if (F.characteristic() < DOUBLE_TO_FLOAT_CROSSOVER)
                     return Protected::fgemm_convert<Givaro::ModularBalanced<float>,Field>(F,ta,tb,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc,H);
-                else if (!std::is_same<Field,Givaro::ModularBalanced<double> >::value && 16*F.cardinality() < Givaro::ModularBalanced<double>::maxCardinality())
+                else if (!std::is_same<Field,Givaro::ModularBalanced<double> >::value &&
+                         !std::is_same<Field,Givaro::Modular<double> >::value &&
+                         16*F.cardinality() < Givaro::ModularBalanced<double>::maxCardinality())
                     return Protected::fgemm_convert<Givaro::ModularBalanced<double>,Field>(F,ta,tb,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc,H);
             }
         }


### PR DESCRIPTION
When fgemm is launched with `Modular<double>` one should definitely stick to this field and not try to convert to ModularBalanced<double>`.
Suprisingly, the corresponding test was missing. This PR adds it and fixes #361 in the process.