### PR TITLE
Fix fflas-ffpack.pc.in for issue #364

### DIFF
--- a/fflas-ffpack.pc.in
+++ b/fflas-ffpack.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=@prefix@/lib
+libdir=@libdir@
 includedir=@prefix@/include
 
 Name: fflas-ffpack


### PR DESCRIPTION
While `libdir` is not actively used in `Libs` - because the right value is actually passed as part of `PRECOMPILE_LIBS` - its presence and value triggers warnings in automated QA check in downstream distribution.