### PR TITLE
Give cblas_ssyrk a return type

### DIFF
--- a/fflas-ffpack/config-blas.h
+++ b/fflas-ffpack/config-blas.h
@@ -288,7 +288,7 @@ extern "C" {
             sgemm_ ( EXT_BLAS_TRANSPOSE(TransA), EXT_BLAS_TRANSPOSE(TransB), &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
     }
 
-    static inline cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+    static inline void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
                               const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
                               const float alpha, const float *A, const int lda,
                               const float beta, float *C, const int ldc){


### PR DESCRIPTION
In the `!__FFLASFFPACK_HAVE_CBLAS` case, the `cblas_ssyrk` definition lacks a return type.