### PR TITLE
Switch config to /bin/sh

### DIFF
--- a/fflas-ffpack-config.in
+++ b/fflas-ffpack-config.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Coypright (c) 2011 FFLAS-FFPACK
 # written by Brice Boyer (briceboyer) <boyer.brice@gmail.com>
 # adapted from LinBox configuration


### PR DESCRIPTION
It doesn't seem to use any bash-specific features, and this makes life slightly easier for downstream distributors, since you don't have to deal with that dependency.