### PR TITLE
Add declarations for ssyrk_ and dsyrk_ when cblas is not available

### DIFF
--- a/fflas-ffpack/config-blas.h
+++ b/fflas-ffpack/config-blas.h
@@ -128,6 +128,8 @@ extern "C" {
     void strmm_ (const char*, const char*, const char*, const char*, const int*, const int*, const float*, const float*, const int*, float*, const int*);
     void sgemm_ (const char*, const char*, const int*, const int*, const int*, const float*, const float*, const int*, const float*, const int*, const float*, float*, const int*);
     void dgemm_ (const char*, const char*, const int*, const int*, const int*, const double*, const double*, const int*, const double*, const int*, const double*, double*, const int*);
+    void ssyrk_ (const char*, const char*, const int*, const int*, const float*, const float*, const int*, const float*, float*, const int*);
+    void dsyrk_ (const char*, const char*, const int*, const int*, const double*, const double*, const int*, const double*, double*, const int*);
 }
 
 // define C wrappers
@@ -293,18 +295,18 @@ extern "C" {
                               const float alpha, const float *A, const int lda,
                               const float beta, float *C, const int ldc){
        if (Order == CblasRowMajor)
-           ssyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
+           ssyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), &N, &K, &alpha, A, &lda, &beta, C, &ldc); // @TODO check this
        else
-           ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
+           ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), &N, &K, &alpha, A, &lda, &beta, C, &ldc);
     }
     void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const double alpha, const double *A, const int lda,
                      const double beta, double *C, const int ldc){
         if (Order == CblasRowMajor)
-            dsyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
+            dsyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), &N, &K, &alpha, A, &lda, &beta, C, &ldc); // @TODO check this
         else
-            dsyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
+            dsyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), &N, &K, &alpha, A, &lda, &beta, C, &ldc);
     }
 
 }

--- a/fflas-ffpack/config-blas.h
+++ b/fflas-ffpack/config-blas.h
@@ -299,7 +299,7 @@ extern "C" {
        else
            ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), &N, &K, &alpha, A, &lda, &beta, C, &ldc);
     }
-    void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+    static inline void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
                  const double alpha, const double *A, const int lda,
                      const double beta, double *C, const int ldc){


### PR DESCRIPTION
Otherwise, we get the following in config.log even when BLAS is available:

```c
configure:18317: g++ -o conftest  -std=gnu++14 -g3 -O2  -w  -I. -I.. -I. -I./fflas-ffpack -I/M2/M2/BUILD/usr-host/include  -I/M2/M2/BUILD/../include -I/M2/M2\
/BUILD/include -I/M2/M2/BUILD/usr-host/include -isystem /usr/include/libxml2    -DNDEBUG -I/usr/include/eigen3  -I/usr/include/python3.6m -I/usr/include -DBO\
OST_STACKTRACE_LINK -L/M2/M2/BUILD/usr-host/lib -g3 -L/usr/lib64 conftest.cpp  -lrefblas -llapack >&5
In file included from conftest.cpp:68:
fflas-ffpack/config-blas.h: In function 'void cblas_ssyrk(CBLAS_ORDER, CBLAS_UPLO, CBLAS_TRANSPOSE, int, int, float, const float*, int, float, float*, int)':
fflas-ffpack/config-blas.h:296:12: error: 'ssyrk_' was not declared in this scope
            ssyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
            ^~~~~~
fflas-ffpack/config-blas.h:296:12: note: suggested alternative: 'sscal_'
            ssyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
            ^~~~~~
            sscal_
fflas-ffpack/config-blas.h:298:12: error: 'ssyrk_' was not declared in this scope
            ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
            ^~~~~~
fflas-ffpack/config-blas.h:298:12: note: suggested alternative: 'sscal_'
            ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
            ^~~~~~
            sscal_
fflas-ffpack/config-blas.h: In function 'void cblas_dsyrk(CBLAS_ORDER, CBLAS_UPLO, CBLAS_TRANSPOSE, int, int, double, const double*, int, double, double*, in\
t)':
fflas-ffpack/config-blas.h:305:13: error: 'dsyrk_' was not declared in this scope
             dsyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
             ^~~~~~
fflas-ffpack/config-blas.h:305:13: note: suggested alternative: 'dscal_'
             dsyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
             ^~~~~~
             dscal_
fflas-ffpack/config-blas.h:307:13: error: 'dsyrk_' was not declared in this scope
             dsyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
             ^~~~~~
fflas-ffpack/config-blas.h:307:13: note: suggested alternative: 'dscal_'
             dsyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc);
             ^~~~~~
             dscal_
configure:18317: $? = 1
configure: program exited with status 1
```