### PR TITLE
Fix detection of MKL

### DIFF
--- a/macros/mkl-check.m4
+++ b/macros/mkl-check.m4
@@ -27,9 +27,8 @@ dnl/
 AC_DEFUN([FF_CHECK_MKL],
 		[
 		AC_MSG_CHECKING(for use of MKL)
-		dnl  echo $CBLAS_LIBS
-                USE_MKL="false"
-		MKL_USED=`echo $CBLAS_LIBS | grep -i MKL`
+		USE_MKL="false"
+		MKL_USED=`echo $BLAS_LIBS | grep -i MKL`
 		AS_IF( [test -n "$MKL_USED"] , [
 			AC_DEFINE(HAVE_MKL,1,[Define if we use MKL for blas/lapack])
 			USE_MKL="true"


### PR DESCRIPTION
We were grepping `CBLAS_LIBS` and not `BLAS_LIBS`, the variable that's set by `--with-blas-libs`.

Also remove some cruft (a comment w/ `echo $CBLAS_LIBS`) and fix nearby indentation (tabs, not spaces, for consistency).

Closes: #406 